### PR TITLE
hotfix sql command insertions

### DIFF
--- a/sql/custom/world/2016_11_10_00_world_objscale.sql
+++ b/sql/custom/world/2016_11_10_00_world_objscale.sql
@@ -1,6 +1,6 @@
 -- gameobject
 ALTER TABLE `gameobject`ADD COLUMN `size` FLOAT NOT NULL DEFAULT '-1';
-INSERT INTO `command` (`name`, `help`) VALUES ('gobject set scale',  'Syntax: .gobject set scale #guid #scale\r\n\r\nGameobject with DB guid #guid size changed to #scale. Gameobject scale saved to DB and persistent. Does not affect other gameobjects of same entry. Using -1 scale uses the default scale from template.');
+INSERT INTO `command` (`name`, `help`) VALUES ('gobject set scale', 'Syntax: .gobject set scale #guid #scale\r\n\r\nGameobject with DB guid #guid size changed to #scale. Gameobject scale saved to DB and persistent. Does not affect other gameobjects of same entry. Using -1 scale uses the default scale from template.');
 
 -- creature
 ALTER TABLE `creature` ADD COLUMN `size` FLOAT NOT NULL DEFAULT '-1';

--- a/sql/custom/world/2016_11_10_00_world_objscale.sql
+++ b/sql/custom/world/2016_11_10_00_world_objscale.sql
@@ -1,7 +1,7 @@
 -- gameobject
 ALTER TABLE `gameobject`ADD COLUMN `size` FLOAT NOT NULL DEFAULT '-1';
-INSERT INTO `command` (`name`, `permission`, `help`) VALUES ('gobject set scale', 1398, 'Syntax: .gobject set scale #guid #scale\r\n\r\nGameobject with DB guid #guid size changed to #scale. Gameobject scale saved to DB and persistent. Does not affect other gameobjects of same entry. Using -1 scale uses the default scale from template.');
+INSERT INTO `command` (`name`, `help`) VALUES ('gobject set scale',  'Syntax: .gobject set scale #guid #scale\r\n\r\nGameobject with DB guid #guid size changed to #scale. Gameobject scale saved to DB and persistent. Does not affect other gameobjects of same entry. Using -1 scale uses the default scale from template.');
 
 -- creature
 ALTER TABLE `creature` ADD COLUMN `size` FLOAT NOT NULL DEFAULT '-1';
-INSERT INTO `command` (`name`, `permission`, `help`) VALUES ('npc set scale', 1589, 'Syntax: .npc set scale #scale\r\n\r\nSelected NPC size changed to #scale. NPC scale saved to DB and persistent. Does not affect other creatures of same entry. Using -1 scale uses the default scale from template.');
+INSERT INTO `command` (`name`, `help`) VALUES ('npc set scale', 'Syntax: .npc set scale #scale\r\n\r\nSelected NPC size changed to #scale. NPC scale saved to DB and persistent. Does not affect other creatures of same entry. Using -1 scale uses the default scale from template.');


### PR DESCRIPTION
I stumbled on a small sql error while integrating this project into a fresh core. 
It seems, that there has been a change in Trinitycore database structure, the command table doesn't have field permission anymore, therefore it fails while trying to insert into it. I couldn't really locate, on which core rev this change took place.

The herby proposed changes should fix this issue. I didn't check other branches of the project, as I'm only using 3.3.5 for now.

ATTENTION required: this change only "hot/hack"-fixes the problem at hand. There is still a sql file in sql/custom/auth which inserts something related to these rbacs into the auth database. As I don't understand the rbac system completely, I can't really tell, if those DB changes are obsolete as well or still very much needed.

Just a (maybe insignificant) question: If a change to a "date_signed" sql file is made, wouldn't it (at least for semantical correctness) be necessary to also change the date in the filename? 
I don't really understand in which Order the SQL auto-Updater is processing all the sql files. 
Is it TDB > updates(FIFO) > custom (FIFO) ?

**Changes proposed**:

- remove permission "rbac int" from command insert statement

Branch 3.3.5
"Used Cor Rev. d665c68cfcf1" 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: it builds on my debian system(I don't know, why it fails in the CI, its just a sql fix, there should be no change in core-build status), sql file is processed without failure, functionality of commands tested ingame.

**Known issues and TODO list**:

- [ ] 
- [ ] 
