### PR TITLE
Add database checks to CI

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [master, dressnpcs_master, gomove_master, multivendor_master, objscale_master, playeritemgossip_master]
+        branch: [master, dressnpcs_master, dressnpcs_master_sql_ci, gomove_master, multivendor_master, objscale_master, playeritemgossip_master]
         pch: [ON, OFF]
         include:
           - branch: objscale_master

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -12,12 +12,29 @@ jobs:
       matrix:
         branch: [master, dressnpcs_master, gomove_master, multivendor_master, objscale_master, playeritemgossip_master]
         pch: [ON, OFF]
+        include:
+          - branch: objscale_master
+            world:
+              - src/server/scripts/Custom/objscale/sql/2016_11_10_00_world_objscale.sql
+        include:
+          - branch: multivendor_master
+            world:
+              - src/server/scripts/Custom/Multivendor/MultivendorExample.sql
+        include:
+          - branch: dressnpcs_master
+            world:
+              - src/server/scripts/Custom/DressNPCs/sql/world.sql
+              - src/server/scripts/Custom/DressNPCs/Example.sql
+              # - src/server/scripts/Custom/DressNPCs/CopyPlayer.sql
+            hotfixes:
+              - src/server/scripts/Custom/DressNPCs/sql/hotfixes.sql
     env:
       BRANCH: ${{ matrix.branch }}
       PCH: ${{ matrix.pch }}
-      SQL_WORLD: ${{ matrix.world }}
-      SQL_CHAR: ${{ matrix.char }}
-      SQL_AUTH: ${{ matrix.auth }}
+      SQL_WORLD: ${{ join( matrix.world, ' ' ) }}
+      SQL_CHAR: ${{ join( matrix.char, ' ' ) }}
+      SQL_AUTH: ${{ join( matrix.auth, ' ' ) }}
+      SQL_HOTFIX: ${{ join( matrix.hotfix, ' ' ) }}
 
     runs-on: ubuntu-20.04
     steps:
@@ -58,6 +75,47 @@ jobs:
         cd bin/check_install/bin
         ./bnetserver --version
         ./worldserver --version
+    - name: Find latest DB release tag
+      id: find_matching_tags
+      uses: Rochet2/find-matching-tags-ghapi@v1.1
+      with:
+        regex: ^TDB\d+\.\d+$
+        sort: desc
+        owner: TrinityCore
+        repo: TrinityCore
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Download latest DB
+      uses: i3h/download-release-asset@6a9870c8f1c561f9e67550d6177c31c2b1c49fef
+      with:
+        owner: TrinityCore
+        repo: TrinityCore
+        tag: ${{ fromJson(steps.find_matching_tags.outputs.tags)[0] }}
+        file: /TDB_full.*\.7z/
+        path: bin/check_install/bin
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Set configs
+      run: |
+        cd bin/check_install/etc
+        sed "s/127.0.0.1;3306;trinity;trinity;/localhost;3306;root;;/g" worldserver.conf.dist > worldserver.conf
+    - name: Build DB
+      run: |
+        echo "start mysql"
+        sudo systemctl start mysql.service
+        echo "remove user password"
+        mysql -uroot -proot -e 'SET PASSWORD FOR root@localhost="";'
+        echo "create databases"
+        mysql -uroot -e 'create database test_mysql;'
+        cd bin/check_install/bin
+        7z x ./*.7z
+        ./worldserver --update-databases-only
+
+    - name: Run SQLs
+      if: matrix.pch == 'ON'
+      run: |
+        for f in $SQL_WORLD; do echo "$f"; cat "$f" | mysql -uroot world; done
+        for f in $SQL_CHAR; do echo "$f"; cat "$f" | mysql -uroot characters; done
+        for f in $SQL_AUTH; do echo "$f"; cat "$f" | mysql -uroot auth; done
+        for f in $SQL_HOTFIX; do echo "$f"; cat "$f" | mysql -uroot hotfixes; done
 
     - name: Push changes
       if: matrix.pch == 'ON'
@@ -74,6 +132,25 @@ jobs:
           - branch: transmog_3.3.5
             world:
               - src/server/scripts/Custom/Transmog/sql/world_NPC.sql
+          - branch: transmogvendor_3.3.5
+            world:
+              - src/server/scripts/Custom/TransmogDisplayVendor/sql/world_NPC.sql
+          - branch: transmog_legion_3.3.5
+            world:
+              - src/server/scripts/Custom/Transmog/sql/world_NPC.sql
+              # - src/server/scripts/Custom/Transmog/sql/completed_quest_items_to_transmog_collection.sql
+          - branch: reforging_3.3.5
+            world:
+              - src/server/scripts/Custom/Reforging/sql/world_npc.sql
+          - branch: multivendor_3.3.5
+            world:
+              - src/server/scripts/Custom/Multivendor/MultivendorExample.sql
+          - branch: multitrainer_3.3.5
+            world:
+              - src/server/scripts/Custom/multitrainer/MultitrainerExample.sql
+          - branch: dressnpcs_3.3.5
+            world:
+              - src/server/scripts/Custom/DressNPCs/Example.sql
     env:
       BRANCH: ${{ matrix.branch }}
       PCH: ${{ matrix.pch }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -77,9 +77,9 @@ jobs:
     env:
       BRANCH: ${{ matrix.branch }}
       PCH: ${{ matrix.pch }}
-      SQL_WORLD: ${{ matrix.world }}
-      SQL_CHAR: ${{ matrix.char }}
-      SQL_AUTH: ${{ matrix.auth }}
+      SQL_WORLD: ${{ join( matrix.world, ' ' ) }}
+      SQL_CHAR: ${{ join( matrix.char, ' ' ) }}
+      SQL_AUTH: ${{ join( matrix.auth, ' ' ) }}
 
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [master, dressnpcs_master, dressnpcs_master_sql_ci, gomove_master, multivendor_master, objscale_master, playeritemgossip_master]
+        branch: [master, dressnpcs_master, gomove_master, multivendor_master, objscale_master, playeritemgossip_master]
         pch: [ON, OFF]
         include:
           - branch: objscale_master

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -70,6 +70,10 @@ jobs:
       matrix:
         branch: [3.3.5, transmog_3.3.5, transmog_legion_3.3.5, transmogvendor_3.3.5, reforging_3.3.5, multivendor_3.3.5, multitrainer_3.3.5, playeritemgossip_3.3.5, dressnpcs_3.3.5, objscale_3.3.5, gomove_3.3.5]
         pch: [ON, OFF]
+        include:
+          - branch: transmog_3.3.5
+            world:
+              - src/server/scripts/Custom/Transmog/sql/world_NPC.sql
     env:
       BRANCH: ${{ matrix.branch }}
       PCH: ${{ matrix.pch }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -16,17 +16,15 @@ jobs:
           - branch: objscale_master
             world:
               - src/server/scripts/Custom/objscale/sql/2016_11_10_00_world_objscale.sql
-        include:
           - branch: multivendor_master
             world:
               - src/server/scripts/Custom/Multivendor/MultivendorExample.sql
-        include:
           - branch: dressnpcs_master
             world:
               - src/server/scripts/Custom/DressNPCs/sql/world.sql
               - src/server/scripts/Custom/DressNPCs/Example.sql
               # - src/server/scripts/Custom/DressNPCs/CopyPlayer.sql
-            hotfixes:
+            hotfix:
               - src/server/scripts/Custom/DressNPCs/sql/hotfixes.sql
     env:
       BRANCH: ${{ matrix.branch }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -160,7 +160,7 @@ jobs:
         for f in $SQL_AUTH; do echo "$f"; cat "$f" | mysql -uroot auth; done
 
     - name: Run External SQLs
-      if: matrix.pch == 'ON' and matrix.branch == 3.3.5
+      if: matrix.pch == 'ON' && matrix.branch == 3.3.5
       run: |
         echo 'Trinity_Jukebox' ; curl -sSf http://rochet2.github.io/downloads/Trinity_Jukebox.sql | mysql -uroot world
         echo 'Trinity_Portal_Master' ; curl -sSf http://rochet2.github.io/downloads/Trinity_Portal_Master.sql | mysql -uroot world

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -15,6 +15,9 @@ jobs:
     env:
       BRANCH: ${{ matrix.branch }}
       PCH: ${{ matrix.pch }}
+      SQL_WORLD: ${{ matrix.world }}
+      SQL_CHAR: ${{ matrix.char }}
+      SQL_AUTH: ${{ matrix.auth }}
 
     runs-on: ubuntu-20.04
     steps:
@@ -92,27 +95,6 @@ jobs:
         git submodule update --init --recursive
         git status
 
-    - name: Check database
-      run: |
-        echo "start mysql"
-        sudo systemctl start mysql.service
-        echo "remove user password"
-        mysql -uroot -proot -e 'SET PASSWORD FOR root@localhost="";'
-        echo "create databases"
-        mysql -uroot -e 'create database test_mysql;'
-        mysql -uroot < sql/create/create_mysql.sql
-        mysql -uroot auth < sql/base/auth_database.sql
-        mysql -uroot characters < sql/base/characters_database.sql
-        mysql -uroot world < sql/base/dev/world_database.sql
-        echo "run updates"
-        chmod +x contrib/check_updates.sh
-        ./contrib/check_updates.sh auth 3.3.5 auth localhost
-        ./contrib/check_updates.sh characters 3.3.5 characters localhost
-        cat sql/updates/world/3.3.5/*.sql | mysql -uroot world
-        echo "custom/auth"; cat sql/custom/auth/*.sql | mysql -uroot auth
-        echo "custom/characters"; cat sql/custom/characters/*.sql | mysql -uroot characters
-        echo "custom/world"; cat sql/custom/world/*.sql | mysql -uroot world
-
     - name: Dependencies
       run: |
         sudo apt-get update && sudo apt-get install -yq libboost-all-dev g++-8
@@ -136,6 +118,53 @@ jobs:
         cd bin/check_install/bin
         ./authserver --version
         ./worldserver --version
+    - name: Find latest DB release tag
+      id: find_matching_tags
+      uses: Rochet2/find-matching-tags-ghapi@v1.1
+      with:
+        regex: ^TDB335\.\d+$
+        sort: desc
+        owner: TrinityCore
+        repo: TrinityCore
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Download latest DB
+      uses: i3h/download-release-asset@6a9870c8f1c561f9e67550d6177c31c2b1c49fef
+      with:
+        owner: TrinityCore
+        repo: TrinityCore
+        tag: ${{ fromJson(steps.find_matching_tags.outputs.tags)[0] }}
+        file: /TDB_full.*\.7z/
+        path: bin/check_install/bin
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Set configs
+      run: |
+        cd bin/check_install/etc
+        sed "s/127.0.0.1;3306;trinity;trinity;/localhost;3306;root;;/g" worldserver.conf.dist > worldserver.conf
+    - name: Build DB
+      run: |
+        echo "start mysql"
+        sudo systemctl start mysql.service
+        echo "remove user password"
+        mysql -uroot -proot -e 'SET PASSWORD FOR root@localhost="";'
+        echo "create databases"
+        mysql -uroot -e 'create database test_mysql;'
+        cd bin/check_install/bin
+        7z x ./*.7z
+        ./worldserver --update-databases-only
+
+    - name: Run SQLs
+      if: matrix.pch == 'ON'
+      run: |
+        for f in $SQL_WORLD; do echo "$f"; cat "$f" | mysql -uroot world; done
+        for f in $SQL_CHAR; do echo "$f"; cat "$f" | mysql -uroot characters; done
+        for f in $SQL_AUTH; do echo "$f"; cat "$f" | mysql -uroot auth; done
+
+    - name: Run External SQLs
+      if: matrix.pch == 'ON' and matrix.branch == 3.3.5
+      run: |
+        echo 'Trinity_Jukebox' ; curl -sSf http://rochet2.github.io/downloads/Trinity_Jukebox.sql | mysql -uroot world
+        echo 'Trinity_Portal_Master' ; curl -sSf http://rochet2.github.io/downloads/Trinity_Portal_Master.sql | mysql -uroot world
+        echo 'Trinity_Portal_Master_Option' ; curl -sSf http://rochet2.github.io/downloads/Trinity_Portal_Master_Option.sql | mysql -uroot world
 
     - name: Push changes
       if: matrix.pch == 'ON'

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -160,7 +160,7 @@ jobs:
         for f in $SQL_AUTH; do echo "$f"; cat "$f" | mysql -uroot auth; done
 
     - name: Run External SQLs
-      if: matrix.pch == 'ON' && matrix.branch == 3.3.5
+      if: matrix.pch == 'ON' && matrix.branch == '3.3.5'
       run: |
         echo 'Trinity_Jukebox' ; curl -sSf http://rochet2.github.io/downloads/Trinity_Jukebox.sql | mysql -uroot world
         echo 'Trinity_Portal_Master' ; curl -sSf http://rochet2.github.io/downloads/Trinity_Portal_Master.sql | mysql -uroot world

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -77,6 +77,9 @@ jobs:
     env:
       BRANCH: ${{ matrix.branch }}
       PCH: ${{ matrix.pch }}
+      SQL_WORLD: ${{ matrix.world }}
+      SQL_CHAR: ${{ matrix.char }}
+      SQL_AUTH: ${{ matrix.auth }}
 
     runs-on: ubuntu-20.04
     steps:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # TrinityCore patches
 
-Take a look at the `src/server/scripts/Custom/*/README.md` in the branches at
+Automerge with latest TC: [![merge](https://github.com/Rochet2/TrinityCore/actions/workflows/merge.yml/badge.svg)](https://github.com/Rochet2/TrinityCore/actions/workflows/merge.yml)
+
+**Take a look at the `src/server/scripts/Custom/*/README.md` in the branches at**
 - https://github.com/Rochet2/TrinityCore/branches/all?query=3.3.5
 - https://github.com/Rochet2/TrinityCore/branches/all?query=master


### PR DESCRIPTION
The different branches have various changes to database, However, almost none of them are being tested by the auto merger.

This PR adds automatic setup of the database using auto updater which will error out if the SQLs fail due to DB structure changes.
Table creation should be done by the auto updater. Any additional SQL scripts can be set up using the CI matrix.
A few of the SQLs are not tested (yet) as they are utilities. They are commented out.

Additionally, a few SQLs from external sources are being tested in `Run External SQLs` step.