### PR TITLE
[Feature]Optional pink link color in chat message.

### DIFF
--- a/src/server/game/Entities/Item/Transmogrification.cpp
+++ b/src/server/game/Entities/Item/Transmogrification.cpp
@@ -214,7 +214,7 @@ std::string Transmogrification::GetItemLink(Item* item, WorldSession* session, b
     const ItemTemplate* temp = item->GetTemplate();
     uint32 color;
 
-    if (isGossipMenu && UseRetailStyleLinks)
+    if (!isGossipMenu && UseRetailStyleLinks)
         color = 0xffff80ff;
     else
         color = ItemQualityColors[temp->Quality];
@@ -240,7 +240,7 @@ std::string Transmogrification::GetItemLink(uint32 entry, WorldSession* session,
     const ItemTemplate* temp = sObjectMgr->GetItemTemplate(entry);
     uint32 color;
 
-    if (isGossipMenu && UseRetailStyleLinks)
+    if (!isGossipMenu && UseRetailStyleLinks)
         color = 0xffff80ff;
     else
         color = ItemQualityColors[temp->Quality];

--- a/src/server/game/Entities/Item/Transmogrification.cpp
+++ b/src/server/game/Entities/Item/Transmogrification.cpp
@@ -207,13 +207,20 @@ std::string Transmogrification::GetItemName(Item const* item, WorldSession* sess
     return name;
 }
 
-std::string Transmogrification::GetItemLink(Item* item, WorldSession* session)
+std::string Transmogrification::GetItemLink(Item* item, WorldSession* session, bool isGossipMenu)
 {
     TC_LOG_DEBUG("custom.transmog", "Transmogrification::GetItemLink");
 
     const ItemTemplate* temp = item->GetTemplate();
+    uint32 color;
+
+    if (isGossipMenu && UseRetailStyleLinks)
+        color = 0xffff80ff;
+    else
+        color = ItemQualityColors[temp->Quality];
+
     std::ostringstream oss;
-    oss << "|c" << std::hex << ItemQualityColors[temp->Quality] << std::dec <<
+    oss << "|c" << std::hex << color << std::dec <<
         "|Hitem:" << temp->ItemId << ":" <<
         item->GetEnchantmentId(PERM_ENCHANTMENT_SLOT) << ":" <<
         item->GetEnchantmentId(SOCK_ENCHANTMENT_SLOT) << ":" <<
@@ -226,13 +233,20 @@ std::string Transmogrification::GetItemLink(Item* item, WorldSession* session)
     return oss.str();
 }
 
-std::string Transmogrification::GetItemLink(uint32 entry, WorldSession* session)
+std::string Transmogrification::GetItemLink(uint32 entry, WorldSession* session, bool isGossipMenu)
 {
     TC_LOG_DEBUG("custom.transmog", "Transmogrification::GetItemLink");
 
     const ItemTemplate* temp = sObjectMgr->GetItemTemplate(entry);
+    uint32 color;
+
+    if (isGossipMenu && UseRetailStyleLinks)
+        color = 0xffff80ff;
+    else
+        color = ItemQualityColors[temp->Quality];
+
     std::ostringstream oss;
-    oss << "|c" << std::hex << ItemQualityColors[temp->Quality] << std::dec <<
+    oss << "|c" << std::hex << color << std::dec <<
         "|Hitem:" << entry << ":0:0:0:0:0:0:0:0:0|h[" << GetItemName(temp, session) << "]|h|r";
 
     return oss.str();
@@ -475,6 +489,8 @@ void Transmogrification::LoadConfig(bool /*reload*/)
 
     EnableTransmogInfo = sConfigMgr->GetBoolDefault("Transmogrification.EnableTransmogInfo", true);
     TransmogNpcText = uint32(sConfigMgr->GetIntDefault("Transmogrification.TransmogNpcText", 65000));
+
+    UseRetailStyleLinks = sConfigMgr->GetBoolDefault("Transmogrification.UseRetailStyleLinks", false);
 
     std::istringstream issAllowed(sConfigMgr->GetStringDefault("Transmogrification.Allowed", ""));
     std::istringstream issNotAllowed(sConfigMgr->GetStringDefault("Transmogrification.NotAllowed", ""));

--- a/src/server/game/Entities/Item/Transmogrification.h
+++ b/src/server/game/Entities/Item/Transmogrification.h
@@ -33,6 +33,8 @@ public:
     bool EnableTransmogInfo;
     uint32 TransmogNpcText;
 
+    bool UseRetailStyleLinks;
+
     // Use IsAllowed() and IsNotAllowed()
     // these are thread unsafe, but assumed to be data so it should be safe
     std::set<uint32> Allowed;
@@ -85,8 +87,8 @@ public:
     const char * GetSlotName(uint8 slot, WorldSession* session);
     std::string GetItemName(ItemTemplate const* itemTemplate, WorldSession* session);
     std::string GetItemName(Item const* itemTemplate, WorldSession* session);
-    std::string GetItemLink(Item* item, WorldSession* session);
-    std::string GetItemLink(uint32 entry, WorldSession* session);
+    std::string GetItemLink(Item* item, WorldSession* session, bool isGossipMenu = false);
+    std::string GetItemLink(uint32 entry, WorldSession* session, bool isGossipMenu = false);
     Item* GetEquippedItem(Player* player, uint8 slot);
     void UpdateItem(Player* player, Item* item);
 

--- a/src/server/scripts/Custom/Transmog/Transmogrifier.cpp
+++ b/src/server/scripts/Custom/Transmog/Transmogrifier.cpp
@@ -421,7 +421,7 @@ public:
                         switch (std::get<AppearanceType>(v))
                         {
                             case TRANSMOG_TYPE_ITEM:
-                                AddGossipItemFor(player, GOSSIP_ICON_MONEY_BAG, Transmogrification::instance().GetItemIcon(std::get<uint32>(v), 30, 30, -18, 0) + Transmogrification::instance().GetItemLink(std::get<uint32>(v), session), sender, action);
+                                AddGossipItemFor(player, GOSSIP_ICON_MONEY_BAG, Transmogrification::instance().GetItemIcon(std::get<uint32>(v), 30, 30, -18, 0) + Transmogrification::instance().GetItemLink(std::get<uint32>(v), session, true), sender, action);
                                 break;
                             case TRANSMOG_TYPE_ENCHANT:
                             {
@@ -692,7 +692,7 @@ public:
                 {
                     decltype(auto) source = sObjectMgr->GetItemTemplate(appearance);
                     if (source && !Transmogrification::instance().CannotTransmogrifyItemWithItem(player, target, source, true))
-                        actions.emplace_back(appearance, Transmogrification::instance().GetItemLink(source->ItemId, player->GetSession()), Transmogrification::instance().GetItemName(source, player->GetSession()));
+                        actions.emplace_back(appearance, Transmogrification::instance().GetItemLink(source->ItemId, player->GetSession(), true), Transmogrification::instance().GetItemName(source, player->GetSession()));
                 }
             }
             break;

--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -4104,6 +4104,10 @@ PacketSpoof.BanDuration = 86400
 #        Description: A list of item entries that are NOT allowed for transmogrification
 #                     Example: "25 35674 5623"
 #        Default:    ""
+#
+#    Transmogrification.UseRetailStyleLinks
+#        Description: Enables / Disables retail style pink item link in "%s has been added to your appearance collection" message.
+#        Default:    0
 
 Logger.custom.transmog = 3, Console Server
 
@@ -4112,6 +4116,8 @@ Transmogrification.TransmogNpcText = 65000
 
 Transmogrification.Allowed = ""
 Transmogrification.NotAllowed = ""
+
+Transmogrification.UseRetailStyleLinks = 0
 
 #
 #    COPPER COST


### PR DESCRIPTION
Cherry pick from my own edits to transmog system. Normally "%s has been added to your appearance collection" message uses item quality color, this PR adds possibility to set it to retail-like pink (#ff80ff). Links in gossip menu still use item quality color. Includes config allowing to switch between current and new behavior.