### PR TITLE
CI: merge workflow improvements and ccache

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   _master:
@@ -86,11 +87,7 @@ jobs:
       uses: actions/cache/restore@v5
       with:
         path: .ccache
-        key: ccache-master-${{ matrix.branch }}-${{ matrix.pch }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
-        restore-keys: |
-          ccache-master-${{ matrix.branch }}-${{ matrix.pch }}-
-          ccache-master-${{ matrix.branch }}-
-          ccache-master-${{ matrix.pch }}-
+        key: ccache-master-${{ matrix.branch }}-${{ matrix.pch }}
 
     - name: Init ccache directory
       if: steps.upstream.outputs.merge_needed == 'true'
@@ -124,12 +121,20 @@ jobs:
           echo "No ccache objects produced, skipping cache save"
         fi
 
+    - name: Delete previous ccache entry
+      if: success() && steps.upstream.outputs.merge_needed == 'true' && steps.ccache_has_data.outputs.has_data == 'true'
+      continue-on-error: true
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh cache delete "ccache-master-${{ matrix.branch }}-${{ matrix.pch }}" --repo "${{ github.repository }}" || true
+
     - name: Save ccache
       if: success() && steps.upstream.outputs.merge_needed == 'true' && steps.ccache_has_data.outputs.has_data == 'true'
       uses: actions/cache/save@v5
       with:
         path: .ccache
-        key: ccache-master-${{ matrix.branch }}-${{ matrix.pch }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+        key: ccache-master-${{ matrix.branch }}-${{ matrix.pch }}
 
     - name: Check executables
       if: steps.upstream.outputs.merge_needed == 'true'
@@ -277,11 +282,7 @@ jobs:
       uses: actions/cache/restore@v5
       with:
         path: .ccache
-        key: ccache-335-${{ matrix.branch }}-${{ matrix.pch }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
-        restore-keys: |
-          ccache-335-${{ matrix.branch }}-${{ matrix.pch }}-
-          ccache-335-${{ matrix.branch }}-
-          ccache-335-${{ matrix.pch }}-
+        key: ccache-335-${{ matrix.branch }}-${{ matrix.pch }}
 
     - name: Init ccache directory
       if: steps.upstream.outputs.merge_needed == 'true'
@@ -315,12 +316,20 @@ jobs:
           echo "No ccache objects produced, skipping cache save"
         fi
 
+    - name: Delete previous ccache entry
+      if: success() && steps.upstream.outputs.merge_needed == 'true' && steps.ccache_has_data.outputs.has_data == 'true'
+      continue-on-error: true
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh cache delete "ccache-335-${{ matrix.branch }}-${{ matrix.pch }}" --repo "${{ github.repository }}" || true
+
     - name: Save ccache
       if: success() && steps.upstream.outputs.merge_needed == 'true' && steps.ccache_has_data.outputs.has_data == 'true'
       uses: actions/cache/save@v5
       with:
         path: .ccache
-        key: ccache-335-${{ matrix.branch }}-${{ matrix.pch }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+        key: ccache-335-${{ matrix.branch }}-${{ matrix.pch }}
 
     - name: Unit tests
       if: steps.upstream.outputs.merge_needed == 'true'

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -8,9 +8,6 @@ on:
 permissions:
   contents: write
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   _master:
     strategy:
@@ -86,7 +83,7 @@ jobs:
 
     - name: Restore ccache
       if: steps.upstream.outputs.merge_needed == 'true'
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: .ccache
         key: ccache-master-${{ matrix.branch }}-${{ matrix.pch }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
@@ -129,7 +126,7 @@ jobs:
 
     - name: Save ccache
       if: success() && steps.upstream.outputs.merge_needed == 'true' && steps.ccache_has_data.outputs.has_data == 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: .ccache
         key: ccache-master-${{ matrix.branch }}-${{ matrix.pch }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
@@ -143,7 +140,7 @@ jobs:
     - name: Find latest DB release tag
       if: steps.upstream.outputs.merge_needed == 'true'
       id: find_matching_tags
-      uses: Rochet2/find-matching-tags-ghapi@v1.3
+      uses: Rochet2/find-matching-tags-ghapi@v2
       with:
         regex: ^TDB\d{4,}\.\d+$
         sort: desc
@@ -272,7 +269,7 @@ jobs:
 
     - name: Restore ccache
       if: steps.upstream.outputs.merge_needed == 'true'
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: .ccache
         key: ccache-335-${{ matrix.branch }}-${{ matrix.pch }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
@@ -315,7 +312,7 @@ jobs:
 
     - name: Save ccache
       if: success() && steps.upstream.outputs.merge_needed == 'true' && steps.ccache_has_data.outputs.has_data == 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: .ccache
         key: ccache-335-${{ matrix.branch }}-${{ matrix.pch }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
@@ -334,7 +331,7 @@ jobs:
     - name: Find latest DB release tag
       if: steps.upstream.outputs.merge_needed == 'true'
       id: find_matching_tags
-      uses: Rochet2/find-matching-tags-ghapi@v1.3
+      uses: Rochet2/find-matching-tags-ghapi@v2
       with:
         regex: ^TDB335\.\d+$
         sort: desc

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -85,10 +85,11 @@ jobs:
       uses: actions/cache/restore@v4
       with:
         path: ~/.ccache
-        key: ccache-master-${{ matrix.pch }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+        key: ccache-master-${{ matrix.branch }}-${{ matrix.pch }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
         restore-keys: |
+          ccache-master-${{ matrix.branch }}-${{ matrix.pch }}-
+          ccache-master-${{ matrix.branch }}-
           ccache-master-${{ matrix.pch }}-
-          ccache-master-
 
     - name: Setup
       if: steps.upstream.outputs.merge_needed == 'true'
@@ -108,11 +109,11 @@ jobs:
       run: ccache -s
 
     - name: Save ccache
-      if: steps.upstream.outputs.merge_needed == 'true' && matrix.branch == 'master' && matrix.pch == 'ON'
+      if: steps.upstream.outputs.merge_needed == 'true'
       uses: actions/cache/save@v4
       with:
         path: ~/.ccache
-        key: ccache-master-${{ matrix.pch }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+        key: ccache-master-${{ matrix.branch }}-${{ matrix.pch }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
 
     - name: Check executables
       if: steps.upstream.outputs.merge_needed == 'true'
@@ -254,10 +255,11 @@ jobs:
       uses: actions/cache/restore@v4
       with:
         path: ~/.ccache
-        key: ccache-335-${{ matrix.pch }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+        key: ccache-335-${{ matrix.branch }}-${{ matrix.pch }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
         restore-keys: |
+          ccache-335-${{ matrix.branch }}-${{ matrix.pch }}-
+          ccache-335-${{ matrix.branch }}-
           ccache-335-${{ matrix.pch }}-
-          ccache-335-
 
     - name: Setup
       if: steps.upstream.outputs.merge_needed == 'true'
@@ -277,11 +279,11 @@ jobs:
       run: ccache -s
 
     - name: Save ccache
-      if: steps.upstream.outputs.merge_needed == 'true' && matrix.branch == '3.3.5' && matrix.pch == 'ON'
+      if: steps.upstream.outputs.merge_needed == 'true'
       uses: actions/cache/save@v4
       with:
         path: ~/.ccache
-        key: ccache-335-${{ matrix.pch }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+        key: ccache-335-${{ matrix.branch }}-${{ matrix.pch }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
 
     - name: Unit tests
       if: steps.upstream.outputs.merge_needed == 'true'

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   _master:
     strategy:
@@ -40,6 +43,7 @@ jobs:
       CCACHE_COMPRESS: true
       CCACHE_COMPRESSLEVEL: 6
       CCACHE_SLOPPINESS: time_macros,pch_defs,include_file_mtime,include_file_ctime
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
 
     runs-on: ubuntu-22.04
     steps:
@@ -84,12 +88,16 @@ jobs:
       if: steps.upstream.outputs.merge_needed == 'true'
       uses: actions/cache/restore@v4
       with:
-        path: ~/.ccache
+        path: .ccache
         key: ccache-master-${{ matrix.branch }}-${{ matrix.pch }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
         restore-keys: |
           ccache-master-${{ matrix.branch }}-${{ matrix.pch }}-
           ccache-master-${{ matrix.branch }}-
           ccache-master-${{ matrix.pch }}-
+
+    - name: Init ccache directory
+      if: steps.upstream.outputs.merge_needed == 'true'
+      run: mkdir -p .ccache
 
     - name: Setup
       if: steps.upstream.outputs.merge_needed == 'true'
@@ -108,11 +116,22 @@ jobs:
       if: steps.upstream.outputs.merge_needed == 'true'
       run: ccache -s
 
+    - name: Check ccache has data
+      id: ccache_has_data
+      if: success() && steps.upstream.outputs.merge_needed == 'true'
+      run: |
+        if find .ccache -type f -print -quit 2>/dev/null | grep -q .; then
+          echo "has_data=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "has_data=false" >> "$GITHUB_OUTPUT"
+          echo "No ccache objects produced, skipping cache save"
+        fi
+
     - name: Save ccache
-      if: steps.upstream.outputs.merge_needed == 'true'
+      if: success() && steps.upstream.outputs.merge_needed == 'true' && steps.ccache_has_data.outputs.has_data == 'true'
       uses: actions/cache/save@v4
       with:
-        path: ~/.ccache
+        path: .ccache
         key: ccache-master-${{ matrix.branch }}-${{ matrix.pch }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
 
     - name: Check executables
@@ -209,6 +228,7 @@ jobs:
       CCACHE_COMPRESS: true
       CCACHE_COMPRESSLEVEL: 6
       CCACHE_SLOPPINESS: time_macros,pch_defs,include_file_mtime,include_file_ctime
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
 
     runs-on: ubuntu-22.04
     steps:
@@ -254,12 +274,16 @@ jobs:
       if: steps.upstream.outputs.merge_needed == 'true'
       uses: actions/cache/restore@v4
       with:
-        path: ~/.ccache
+        path: .ccache
         key: ccache-335-${{ matrix.branch }}-${{ matrix.pch }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
         restore-keys: |
           ccache-335-${{ matrix.branch }}-${{ matrix.pch }}-
           ccache-335-${{ matrix.branch }}-
           ccache-335-${{ matrix.pch }}-
+
+    - name: Init ccache directory
+      if: steps.upstream.outputs.merge_needed == 'true'
+      run: mkdir -p .ccache
 
     - name: Setup
       if: steps.upstream.outputs.merge_needed == 'true'
@@ -278,11 +302,22 @@ jobs:
       if: steps.upstream.outputs.merge_needed == 'true'
       run: ccache -s
 
+    - name: Check ccache has data
+      id: ccache_has_data
+      if: success() && steps.upstream.outputs.merge_needed == 'true'
+      run: |
+        if find .ccache -type f -print -quit 2>/dev/null | grep -q .; then
+          echo "has_data=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "has_data=false" >> "$GITHUB_OUTPUT"
+          echo "No ccache objects produced, skipping cache save"
+        fi
+
     - name: Save ccache
-      if: steps.upstream.outputs.merge_needed == 'true'
+      if: success() && steps.upstream.outputs.merge_needed == 'true' && steps.ccache_has_data.outputs.has_data == 'true'
       uses: actions/cache/save@v4
       with:
-        path: ~/.ccache
+        path: .ccache
         key: ccache-335-${{ matrix.branch }}-${{ matrix.pch }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
 
     - name: Unit tests

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -147,6 +147,7 @@ jobs:
         owner: TrinityCore
         repo: TrinityCore
         paginate: 'true'
+        per_page: 100
     - name: Download latest DB
       if: steps.upstream.outputs.merge_needed == 'true'
       env:
@@ -342,6 +343,7 @@ jobs:
         owner: TrinityCore
         repo: TrinityCore
         paginate: 'true'
+        per_page: 100
     - name: Download latest DB
       if: steps.upstream.outputs.merge_needed == 'true'
       env:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -151,7 +151,6 @@ jobs:
         sort: desc
         owner: TrinityCore
         repo: TrinityCore
-        paginate: 'true'
         per_page: 100
     - name: Download latest DB
       if: steps.upstream.outputs.merge_needed == 'true'
@@ -347,11 +346,10 @@ jobs:
       id: find_matching_tags
       uses: Rochet2/find-matching-tags-ghapi@v2
       with:
-        regex: ^TDB335\.\d+$
+        regex: ^TDB335\.\d{5,}$
         sort: desc
         owner: TrinityCore
         repo: TrinityCore
-        paginate: 'true'
         per_page: 100
     - name: Download latest DB
       if: steps.upstream.outputs.merge_needed == 'true'

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -36,6 +36,10 @@ jobs:
       SQL_CHAR: ${{ join( matrix.char, ' ' ) }}
       SQL_AUTH: ${{ join( matrix.auth, ' ' ) }}
       SQL_HOTFIX: ${{ join( matrix.hotfix, ' ' ) }}
+      CCACHE_MAXSIZE: 500M
+      CCACHE_COMPRESS: true
+      CCACHE_COMPRESSLEVEL: 6
+      CCACHE_SLOPPINESS: time_macros,pch_defs,include_file_mtime,include_file_ctime
 
     runs-on: ubuntu-22.04
     steps:
@@ -52,11 +56,12 @@ jobs:
         git remote add Trinity https://github.com/TrinityCore/TrinityCore.git || git remote set-url Trinity https://github.com/TrinityCore/TrinityCore.git
         git fetch Trinity master
         if git merge-base --is-ancestor Trinity/master HEAD; then
-          echo "merge_needed=false" >> "$GITHUB_OUTPUT"
-          echo "Already up to date with TrinityCore master, skipping merge and build"
+          echo "Already up to date with TrinityCore master"
         else
-          echo "merge_needed=true" >> "$GITHUB_OUTPUT"
+          echo "Upstream merge required"
         fi
+        # BENCHMARK: upstream skip disabled — restore merge_needed=false branch below
+        echo "merge_needed=true" >> "$GITHUB_OUTPUT"
 
     - name: Configure user
       if: steps.upstream.outputs.merge_needed == 'true'
@@ -73,19 +78,42 @@ jobs:
     - name: Dependencies
       if: steps.upstream.outputs.merge_needed == 'true'
       run: |
-        sudo apt-get update && sudo apt-get install -yq libboost-all-dev clang-15
+        sudo apt-get update && sudo apt-get install -yq libboost-all-dev clang-15 ccache
+
+    - name: Restore ccache
+      if: steps.upstream.outputs.merge_needed == 'true'
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/.ccache
+        key: ccache-master-${{ matrix.pch }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+        restore-keys: |
+          ccache-master-${{ matrix.pch }}-
+          ccache-master-
+
     - name: Setup
       if: steps.upstream.outputs.merge_needed == 'true'
       run: |
         mkdir bin
         cd bin
-        cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=$PCH -DUSE_SCRIPTPCH=$PCH -DTOOLS=1 -DSCRIPTS=dynamic -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_INSTALL_PREFIX=check_install -DCMAKE_C_COMPILER=clang-15 -DCMAKE_CXX_COMPILER=clang++-15
+        cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=$PCH -DUSE_SCRIPTPCH=$PCH -DTOOLS=1 -DSCRIPTS=dynamic -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_INSTALL_PREFIX=check_install -DCMAKE_C_COMPILER=clang-15 -DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cd ..
     - name: Build
       if: steps.upstream.outputs.merge_needed == 'true'
       run: |
         cd bin
         make -j 4 -k && make install
+
+    - name: ccache stats
+      if: steps.upstream.outputs.merge_needed == 'true'
+      run: ccache -s
+
+    - name: Save ccache
+      if: steps.upstream.outputs.merge_needed == 'true' && matrix.branch == 'master' && matrix.pch == 'ON'
+      uses: actions/cache/save@v4
+      with:
+        path: ~/.ccache
+        key: ccache-master-${{ matrix.pch }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+
     - name: Check executables
       if: steps.upstream.outputs.merge_needed == 'true'
       run: |
@@ -176,6 +204,10 @@ jobs:
       SQL_WORLD: ${{ join( matrix.world, ' ' ) }}
       SQL_CHAR: ${{ join( matrix.char, ' ' ) }}
       SQL_AUTH: ${{ join( matrix.auth, ' ' ) }}
+      CCACHE_MAXSIZE: 500M
+      CCACHE_COMPRESS: true
+      CCACHE_COMPRESSLEVEL: 6
+      CCACHE_SLOPPINESS: time_macros,pch_defs,include_file_mtime,include_file_ctime
 
     runs-on: ubuntu-22.04
     steps:
@@ -192,11 +224,12 @@ jobs:
         git remote add Trinity https://github.com/TrinityCore/TrinityCore.git || git remote set-url Trinity https://github.com/TrinityCore/TrinityCore.git
         git fetch Trinity 3.3.5
         if git merge-base --is-ancestor Trinity/3.3.5 HEAD; then
-          echo "merge_needed=false" >> "$GITHUB_OUTPUT"
-          echo "Already up to date with TrinityCore 3.3.5, skipping merge and build"
+          echo "Already up to date with TrinityCore 3.3.5"
         else
-          echo "merge_needed=true" >> "$GITHUB_OUTPUT"
+          echo "Upstream merge required"
         fi
+        # BENCHMARK: upstream skip disabled — restore merge_needed=false branch below
+        echo "merge_needed=true" >> "$GITHUB_OUTPUT"
 
     - name: Configure user
       if: steps.upstream.outputs.merge_needed == 'true'
@@ -213,20 +246,43 @@ jobs:
     - name: Dependencies
       if: steps.upstream.outputs.merge_needed == 'true'
       run: |
-        sudo apt-get update && sudo apt-get install -yq libboost-all-dev g++-11
+        sudo apt-get update && sudo apt-get install -yq libboost-all-dev g++-11 ccache
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100 --slave /usr/bin/g++ g++ /usr/bin/g++-11
+
+    - name: Restore ccache
+      if: steps.upstream.outputs.merge_needed == 'true'
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/.ccache
+        key: ccache-335-${{ matrix.pch }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+        restore-keys: |
+          ccache-335-${{ matrix.pch }}-
+          ccache-335-
+
     - name: Setup
       if: steps.upstream.outputs.merge_needed == 'true'
       run: |
         mkdir bin
         cd bin
-        cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=$PCH -DUSE_SCRIPTPCH=$PCH -DTOOLS=1 -DSCRIPTS=dynamic -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_INSTALL_PREFIX=check_install -DBUILD_TESTING=1
+        cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=$PCH -DUSE_SCRIPTPCH=$PCH -DTOOLS=1 -DSCRIPTS=dynamic -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_INSTALL_PREFIX=check_install -DBUILD_TESTING=1 -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cd ..
     - name: Build
       if: steps.upstream.outputs.merge_needed == 'true'
       run: |
         cd bin
         make -j 4 -k && make install
+
+    - name: ccache stats
+      if: steps.upstream.outputs.merge_needed == 'true'
+      run: ccache -s
+
+    - name: Save ccache
+      if: steps.upstream.outputs.merge_needed == 'true' && matrix.branch == '3.3.5' && matrix.pch == 'ON'
+      uses: actions/cache/save@v4
+      with:
+        path: ~/.ccache
+        key: ccache-335-${{ matrix.pch }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+
     - name: Unit tests
       if: steps.upstream.outputs.merge_needed == 'true'
       run: |

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -146,13 +146,17 @@ jobs:
         sort: desc
         owner: TrinityCore
         repo: TrinityCore
-        per_page: 100
-        token: ${{ secrets.GITHUB_TOKEN }}
+        paginate: 'true'
     - name: Download latest DB
       if: steps.upstream.outputs.merge_needed == 'true'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        MATCHED_COUNT: ${{ steps.find_matching_tags.outputs.count }}
       run: |
+        if [ "${MATCHED_COUNT}" -eq 0 ]; then
+          echo "::error::No TDB release tag matched the regex"
+          exit 1
+        fi
         TAG='${{ fromJson(steps.find_matching_tags.outputs.tags)[0] }}'
         gh release download "$TAG" --repo TrinityCore/TrinityCore --pattern 'TDB_full*.7z' --dir bin/check_install/bin
     - name: Set configs
@@ -337,17 +341,19 @@ jobs:
         sort: desc
         owner: TrinityCore
         repo: TrinityCore
-        per_page: 70
-        token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Print matched tags
-      if: steps.upstream.outputs.merge_needed == 'true'
-      run: |
-        echo ${{ steps.find_matching_tags.outputs.tags }}
+        paginate: 'true'
     - name: Download latest DB
       if: steps.upstream.outputs.merge_needed == 'true'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        MATCHED_COUNT: ${{ steps.find_matching_tags.outputs.count }}
+        MATCHED_TAGS: ${{ steps.find_matching_tags.outputs.tags }}
       run: |
+        echo "Matched ${MATCHED_COUNT} tag(s): ${MATCHED_TAGS}"
+        if [ "${MATCHED_COUNT}" -eq 0 ]; then
+          echo "::error::No TDB release tag matched the regex"
+          exit 1
+        fi
         TAG='${{ fromJson(steps.find_matching_tags.outputs.tags)[0] }}'
         gh release download "$TAG" --repo TrinityCore/TrinityCore --pattern 'TDB_full*.7z' --dir bin/check_install/bin
     - name: Print downloaded files

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -109,13 +109,20 @@ jobs:
         cd ..
     - name: Build
       if: steps.upstream.outputs.merge_needed == 'true'
+      id: build
       run: |
+        echo "build_start=$EPOCHSECONDS" >> "$GITHUB_OUTPUT"
+        ccache -z
         cd bin
         make -j 4 -k && make install
 
     - name: ccache stats
-      if: steps.upstream.outputs.merge_needed == 'true'
+      if: always() && steps.upstream.outputs.merge_needed == 'true'
       run: ccache -s
+
+    - name: Prune ccache
+      if: steps.upstream.outputs.merge_needed == 'true'
+      run: ccache --evict-older-than "$(( $EPOCHSECONDS - ${{ steps.build.outputs.build_start }} ))s"
 
     - name: Check ccache has data
       id: ccache_has_data
@@ -304,13 +311,20 @@ jobs:
         cd ..
     - name: Build
       if: steps.upstream.outputs.merge_needed == 'true'
+      id: build
       run: |
+        echo "build_start=$EPOCHSECONDS" >> "$GITHUB_OUTPUT"
+        ccache -z
         cd bin
         make -j 4 -k && make install
 
     - name: ccache stats
-      if: steps.upstream.outputs.merge_needed == 'true'
+      if: always() && steps.upstream.outputs.merge_needed == 'true'
       run: ccache -s
+
+    - name: Prune ccache
+      if: steps.upstream.outputs.merge_needed == 'true'
+      run: ccache --evict-older-than "$(( $EPOCHSECONDS - ${{ steps.build.outputs.build_start }} ))s"
 
     - name: Check ccache has data
       id: ccache_has_data

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -46,38 +46,54 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Check upstream
+      id: upstream
+      run: |
+        git remote add Trinity https://github.com/TrinityCore/TrinityCore.git || git remote set-url Trinity https://github.com/TrinityCore/TrinityCore.git
+        git fetch Trinity master
+        if git merge-base --is-ancestor Trinity/master HEAD; then
+          echo "merge_needed=false" >> "$GITHUB_OUTPUT"
+          echo "Already up to date with TrinityCore master, skipping merge and build"
+        else
+          echo "merge_needed=true" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Configure user
+      if: steps.upstream.outputs.merge_needed == 'true'
       run: |
         git config user.email "rochet2@post.com" && git config user.name "Rochet2"
 
     - name: Merge TC
+      if: steps.upstream.outputs.merge_needed == 'true'
       run: |
-        git status
-        git remote add Trinity https://github.com/TrinityCore/TrinityCore.git
-        git fetch Trinity master
         git merge -m "Merge TrinityCore master to ${BRANCH} [skip ci]" Trinity/master
         git submodule update --init --recursive
         git status
 
     - name: Dependencies
+      if: steps.upstream.outputs.merge_needed == 'true'
       run: |
         sudo apt-get update && sudo apt-get install -yq libboost-all-dev clang-15
     - name: Setup
+      if: steps.upstream.outputs.merge_needed == 'true'
       run: |
         mkdir bin
         cd bin
         cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=$PCH -DUSE_SCRIPTPCH=$PCH -DTOOLS=1 -DSCRIPTS=dynamic -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_INSTALL_PREFIX=check_install -DCMAKE_C_COMPILER=clang-15 -DCMAKE_CXX_COMPILER=clang++-15
         cd ..
     - name: Build
+      if: steps.upstream.outputs.merge_needed == 'true'
       run: |
         cd bin
         make -j 4 -k && make install
     - name: Check executables
+      if: steps.upstream.outputs.merge_needed == 'true'
       run: |
         cd bin/check_install/bin
         ./bnetserver --version
         ./worldserver --version
     - name: Find latest DB release tag
+      if: steps.upstream.outputs.merge_needed == 'true'
       id: find_matching_tags
       uses: Rochet2/find-matching-tags-ghapi@v1.3
       with:
@@ -88,19 +104,19 @@ jobs:
         per_page: 100
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Download latest DB
-      uses: i3h/download-release-asset@a987f9dc3559bd1024d7ed353b59c9d0bbb8ab61
-      with:
-        owner: TrinityCore
-        repo: TrinityCore
-        tag: ${{ fromJson(steps.find_matching_tags.outputs.tags)[0] }}
-        file: /TDB_full.*\.7z/
-        path: bin/check_install/bin
-        token: ${{ secrets.GITHUB_TOKEN }}
+      if: steps.upstream.outputs.merge_needed == 'true'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        TAG='${{ fromJson(steps.find_matching_tags.outputs.tags)[0] }}'
+        gh release download "$TAG" --repo TrinityCore/TrinityCore --pattern 'TDB_full*.7z' --dir bin/check_install/bin
     - name: Set configs
+      if: steps.upstream.outputs.merge_needed == 'true'
       run: |
         cd bin/check_install/etc
         sed "s/127.0.0.1;3306;trinity;trinity;/localhost;3306;root;;/g" worldserver.conf.dist > worldserver.conf
     - name: Build DB
+      if: steps.upstream.outputs.merge_needed == 'true'
       run: |
         echo "start mysql"
         sudo systemctl start mysql.service
@@ -113,7 +129,7 @@ jobs:
         yes | ./worldserver --update-databases-only
 
     - name: Run SQLs
-      if: matrix.pch == 'ON'
+      if: steps.upstream.outputs.merge_needed == 'true' && matrix.pch == 'ON'
       run: |
         for f in $SQL_WORLD; do echo "$f"; cat "$f" | mysql -uroot world; done
         for f in $SQL_CHAR; do echo "$f"; cat "$f" | mysql -uroot characters; done
@@ -121,7 +137,7 @@ jobs:
         for f in $SQL_HOTFIX; do echo "$f"; cat "$f" | mysql -uroot hotfixes; done
 
     - name: Push changes
-      if: matrix.pch == 'ON'
+      if: steps.upstream.outputs.merge_needed == 'true' && matrix.pch == 'ON'
       run: |
         git push
 
@@ -170,43 +186,60 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Check upstream
+      id: upstream
+      run: |
+        git remote add Trinity https://github.com/TrinityCore/TrinityCore.git || git remote set-url Trinity https://github.com/TrinityCore/TrinityCore.git
+        git fetch Trinity 3.3.5
+        if git merge-base --is-ancestor Trinity/3.3.5 HEAD; then
+          echo "merge_needed=false" >> "$GITHUB_OUTPUT"
+          echo "Already up to date with TrinityCore 3.3.5, skipping merge and build"
+        else
+          echo "merge_needed=true" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Configure user
+      if: steps.upstream.outputs.merge_needed == 'true'
       run: |
         git config user.email "rochet2@post.com" && git config user.name "Rochet2"
 
     - name: Merge TC
+      if: steps.upstream.outputs.merge_needed == 'true'
       run: |
-        git status
-        git remote add Trinity https://github.com/TrinityCore/TrinityCore.git
-        git fetch Trinity 3.3.5
         git merge -m "Merge TrinityCore 3.3.5 to ${BRANCH} [skip ci]" Trinity/3.3.5
         git submodule update --init --recursive
         git status
 
     - name: Dependencies
+      if: steps.upstream.outputs.merge_needed == 'true'
       run: |
         sudo apt-get update && sudo apt-get install -yq libboost-all-dev g++-11
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100 --slave /usr/bin/g++ g++ /usr/bin/g++-11
     - name: Setup
+      if: steps.upstream.outputs.merge_needed == 'true'
       run: |
         mkdir bin
         cd bin
         cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=$PCH -DUSE_SCRIPTPCH=$PCH -DTOOLS=1 -DSCRIPTS=dynamic -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_INSTALL_PREFIX=check_install -DBUILD_TESTING=1
         cd ..
     - name: Build
+      if: steps.upstream.outputs.merge_needed == 'true'
       run: |
         cd bin
         make -j 4 -k && make install
     - name: Unit tests
+      if: steps.upstream.outputs.merge_needed == 'true'
       run: |
         cd bin
         make test
     - name: Check executables
+      if: steps.upstream.outputs.merge_needed == 'true'
       run: |
         cd bin/check_install/bin
         ./authserver --version
         ./worldserver --version
     - name: Find latest DB release tag
+      if: steps.upstream.outputs.merge_needed == 'true'
       id: find_matching_tags
       uses: Rochet2/find-matching-tags-ghapi@v1.3
       with:
@@ -217,25 +250,27 @@ jobs:
         per_page: 70
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Print matched tags
+      if: steps.upstream.outputs.merge_needed == 'true'
       run: |
         echo ${{ steps.find_matching_tags.outputs.tags }}
     - name: Download latest DB
-      uses: i3h/download-release-asset@a987f9dc3559bd1024d7ed353b59c9d0bbb8ab61
-      with:
-        owner: TrinityCore
-        repo: TrinityCore
-        tag: ${{ fromJson(steps.find_matching_tags.outputs.tags)[0] }}
-        file: /TDB_full.*\.7z/
-        path: bin/check_install/bin
-        token: ${{ secrets.GITHUB_TOKEN }}
+      if: steps.upstream.outputs.merge_needed == 'true'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        TAG='${{ fromJson(steps.find_matching_tags.outputs.tags)[0] }}'
+        gh release download "$TAG" --repo TrinityCore/TrinityCore --pattern 'TDB_full*.7z' --dir bin/check_install/bin
     - name: Print downloaded files
+      if: steps.upstream.outputs.merge_needed == 'true'
       run: |
         ls -lah bin/check_install/bin
     - name: Set configs
+      if: steps.upstream.outputs.merge_needed == 'true'
       run: |
         cd bin/check_install/etc
         sed "s/127.0.0.1;3306;trinity;trinity;/localhost;3306;root;;/g" worldserver.conf.dist > worldserver.conf
     - name: Build DB
+      if: steps.upstream.outputs.merge_needed == 'true'
       run: |
         echo "start mysql"
         sudo systemctl start mysql.service
@@ -248,20 +283,20 @@ jobs:
         yes | ./worldserver --update-databases-only
 
     - name: Run SQLs
-      if: matrix.pch == 'ON'
+      if: steps.upstream.outputs.merge_needed == 'true' && matrix.pch == 'ON'
       run: |
         for f in $SQL_WORLD; do echo "$f"; cat "$f" | mysql -uroot world; done
         for f in $SQL_CHAR; do echo "$f"; cat "$f" | mysql -uroot characters; done
         for f in $SQL_AUTH; do echo "$f"; cat "$f" | mysql -uroot auth; done
 
     - name: Run External SQLs
-      if: matrix.pch == 'ON' && matrix.branch == '3.3.5'
+      if: steps.upstream.outputs.merge_needed == 'true' && matrix.pch == 'ON' && matrix.branch == '3.3.5'
       run: |
-        echo 'Trinity_Jukebox' ; curl -sSf http://rochet2.github.io/downloads/Trinity_Jukebox.sql | mysql -uroot world
-        echo 'Trinity_Portal_Master' ; curl -sSf http://rochet2.github.io/downloads/Trinity_Portal_Master.sql | mysql -uroot world
-        echo 'Trinity_Portal_Master_Option' ; curl -sSf http://rochet2.github.io/downloads/Trinity_Portal_Master_Option.sql | mysql -uroot world
+        echo 'Trinity_Jukebox' ; curl -sSf https://rochet2.github.io/downloads/Trinity_Jukebox.sql | mysql -uroot world
+        echo 'Trinity_Portal_Master' ; curl -sSf https://rochet2.github.io/downloads/Trinity_Portal_Master.sql | mysql -uroot world
+        echo 'Trinity_Portal_Master_Option' ; curl -sSf https://rochet2.github.io/downloads/Trinity_Portal_Master_Option.sql | mysql -uroot world
 
     - name: Push changes
-      if: matrix.pch == 'ON'
+      if: steps.upstream.outputs.merge_needed == 'true' && matrix.pch == 'ON'
       run: |
         git push

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -42,8 +42,9 @@ jobs:
       CCACHE_COMPRESSLEVEL: 6
       CCACHE_SLOPPINESS: time_macros,pch_defs,include_file_mtime,include_file_ctime
       CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_BASEDIR: ${{ github.workspace }}
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
 
     - uses: actions/checkout@v6
@@ -80,7 +81,10 @@ jobs:
     - name: Dependencies
       if: steps.upstream.outputs.merge_needed == 'true'
       run: |
-        sudo apt-get update && sudo apt-get install -yq libboost-all-dev clang-15 ccache
+        sudo apt-get update && sudo apt-get install -yq ccache clang-17 \
+          libboost-dev libboost-filesystem-dev libboost-locale-dev \
+          libboost-program-options-dev libboost-regex-dev libboost-thread-dev \
+          libssl-dev libreadline-dev zlib1g-dev libbz2-dev
 
     - name: Restore ccache
       if: steps.upstream.outputs.merge_needed == 'true'
@@ -95,10 +99,13 @@ jobs:
 
     - name: Setup
       if: steps.upstream.outputs.merge_needed == 'true'
+      env:
+        CC: /usr/bin/clang-17
+        CXX: /usr/bin/clang++-17
       run: |
         mkdir bin
         cd bin
-        cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=$PCH -DUSE_SCRIPTPCH=$PCH -DTOOLS=1 -DSCRIPTS=dynamic -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_INSTALL_PREFIX=check_install -DCMAKE_C_COMPILER=clang-15 -DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        cmake ../ -DWITH_WARNINGS=1 -DWITH_WARNINGS_AS_ERRORS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=$PCH -DUSE_SCRIPTPCH=$PCH -DTOOLS=1 -DSCRIPTS=dynamic -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_INSTALL_PREFIX=check_install -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cd ..
     - name: Build
       if: steps.upstream.outputs.merge_needed == 'true'
@@ -235,6 +242,7 @@ jobs:
       CCACHE_COMPRESSLEVEL: 6
       CCACHE_SLOPPINESS: time_macros,pch_defs,include_file_mtime,include_file_ctime
       CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_BASEDIR: ${{ github.workspace }}
 
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
## Summary

Workflow improvements to `.github/workflows/merge.yml`:

- **Skip merge and build** when Trinity upstream is already an ancestor of `HEAD` (**benchmark mode currently forces full builds** so ccache can be measured — see #169 to re-enable the skip)
- **HTTPS** for external SQL downloads and **`gh release download`** instead of `i3h/download-release-asset`
- **ccache** with `CMAKE_*_COMPILER_LAUNCHER`, 500MB cap, compression, PCH-friendly sloppiness, `CCACHE_BASEDIR` for path-stable hashes
- **Per-branch + per-PCH cache keys** with explicit `gh cache delete` + `actions/cache/save@v5` so each successful build overwrites the previous entry instead of being silently skipped on key collision
- **`ccache -z` before build, `ccache --evict-older-than` after** for clean per-build stats and pruning of stale objects
- **`_master` job aligned with upstream `linux-build.yml`** — `ubuntu-24.04`, `clang-17`, explicit Boost + ssl/readline/zlib/bz2 packages, `-DWITH_WARNINGS_AS_ERRORS=1` instead of raw `-Werror`
- **3.3.5 TDB tag regex tightened** to `^TDB335\.\d{5,}$` so legacy 2-digit tags (`TDB335.49`–`TDB335.64`) no longer beat modern YY-MM-D suffixes under lex sort
- **`find-matching-tags-ghapi@v2`** with `per_page: 100` and explicit `count` check to fail loudly on no match
- **Node.js 24 actions**: `actions/cache@v5`, `find-matching-tags-ghapi@v2`

## Cache layout

Up to 34 entries total (17 branches × 2 PCH), one stable key per `(job, branch, pch)`:

- `ccache-master-<branch>-<pch>` (6 branches × 2)
- `ccache-335-<branch>-<pch>` (11 branches × 2)

GitHub repo cache limit is 10GB with LRU eviction.

## Benchmark mode

`Check upstream` always sets `merge_needed=true` so every run performs a full build. #169 reverts this once benchmarking is done.

## Test plan

- [ ] Review Actions run on this branch
- [ ] Compare cold vs warm build times and `ccache -s` hit rates per matrix leg
- [ ] Confirm `_master` legs build on `ubuntu-24.04` + `clang-17`
- [ ] Confirm `TDB335.25101` (not `TDB335.64`) is downloaded for 3.3.5 jobs
- [ ] Verify cache entries are overwritten in-place (one per `branch+pch`, not growing)
- [ ] Land #169 on top to re-enable upstream skip before merging to `automerge`