### PR TITLE
CI: re-enable upstream skip (stacked on merge workflow PR)

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -59,12 +59,11 @@ jobs:
         git remote add Trinity https://github.com/TrinityCore/TrinityCore.git || git remote set-url Trinity https://github.com/TrinityCore/TrinityCore.git
         git fetch Trinity master
         if git merge-base --is-ancestor Trinity/master HEAD; then
-          echo "Already up to date with TrinityCore master"
+          echo "merge_needed=false" >> "$GITHUB_OUTPUT"
+          echo "Already up to date with TrinityCore master, skipping merge and build"
         else
-          echo "Upstream merge required"
+          echo "merge_needed=true" >> "$GITHUB_OUTPUT"
         fi
-        # BENCHMARK: upstream skip disabled — restore merge_needed=false branch below
-        echo "merge_needed=true" >> "$GITHUB_OUTPUT"
 
     - name: Configure user
       if: steps.upstream.outputs.merge_needed == 'true'
@@ -266,12 +265,11 @@ jobs:
         git remote add Trinity https://github.com/TrinityCore/TrinityCore.git || git remote set-url Trinity https://github.com/TrinityCore/TrinityCore.git
         git fetch Trinity 3.3.5
         if git merge-base --is-ancestor Trinity/3.3.5 HEAD; then
-          echo "Already up to date with TrinityCore 3.3.5"
+          echo "merge_needed=false" >> "$GITHUB_OUTPUT"
+          echo "Already up to date with TrinityCore 3.3.5, skipping merge and build"
         else
-          echo "Upstream merge required"
+          echo "merge_needed=true" >> "$GITHUB_OUTPUT"
         fi
-        # BENCHMARK: upstream skip disabled — restore merge_needed=false branch below
-        echo "merge_needed=true" >> "$GITHUB_OUTPUT"
 
     - name: Configure user
       if: steps.upstream.outputs.merge_needed == 'true'


### PR DESCRIPTION
## Summary

Re-enables the upstream-skip logic that #168 temporarily disabled for ccache benchmarking.

`Check upstream` now sets `merge_needed=false` when Trinity is already an ancestor of `HEAD`, so jobs skip the merge/build/DB steps on nightly runs when there is nothing new to merge.

Rebased onto `automerge` after #168 was squash-merged. The branch is now a single commit on top of `automerge`.

## Test plan

- [ ] Confirm matrix legs skip merge/build when their branch is already up to date with Trinity
- [ ] Confirm legs still merge and build when upstream has new commits
- [ ] After landing, watch the next scheduled run to verify behavior