### PR TITLE
CI: build 3.3.5 matrix on ubuntu-24.04 with clang-17

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -246,7 +246,7 @@ jobs:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       CCACHE_BASEDIR: ${{ github.workspace }}
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
 
     - uses: actions/checkout@v6
@@ -282,17 +282,19 @@ jobs:
     - name: Dependencies
       if: steps.upstream.outputs.merge_needed == 'true'
       run: |
-        sudo apt-get update && sudo apt-get install -yq libboost-all-dev g++-11 ccache
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100 --slave /usr/bin/g++ g++ /usr/bin/g++-11
+        sudo apt-get update && sudo apt-get install -yq ccache clang-17 \
+          libboost-dev libboost-filesystem-dev libboost-locale-dev \
+          libboost-program-options-dev libboost-regex-dev libboost-thread-dev \
+          libssl-dev libreadline-dev zlib1g-dev libbz2-dev
 
     - name: Restore ccache
       if: steps.upstream.outputs.merge_needed == 'true'
       uses: actions/cache/restore@v5
       with:
         path: .ccache
-        key: ccache-335-${{ matrix.branch }}-${{ matrix.pch }}
+        key: ccache-335-u24-${{ matrix.branch }}-${{ matrix.pch }}
         restore-keys: |
-          ccache-335-3.3.5-${{ matrix.pch }}
+          ccache-335-u24-3.3.5-${{ matrix.pch }}
 
     - name: Init ccache directory
       if: steps.upstream.outputs.merge_needed == 'true'
@@ -300,6 +302,9 @@ jobs:
 
     - name: Setup
       if: steps.upstream.outputs.merge_needed == 'true'
+      env:
+        CC: /usr/bin/clang-17
+        CXX: /usr/bin/clang++-17
       run: |
         mkdir bin
         cd bin
@@ -333,14 +338,14 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh cache delete "ccache-335-${{ matrix.branch }}-${{ matrix.pch }}" --repo "${{ github.repository }}" || true
+        gh cache delete "ccache-335-u24-${{ matrix.branch }}-${{ matrix.pch }}" --repo "${{ github.repository }}" || true
 
     - name: Save ccache
       if: success() && steps.upstream.outputs.merge_needed == 'true' && steps.ccache_has_data.outputs.has_data == 'true'
       uses: actions/cache/save@v5
       with:
         path: .ccache
-        key: ccache-335-${{ matrix.branch }}-${{ matrix.pch }}
+        key: ccache-335-u24-${{ matrix.branch }}-${{ matrix.pch }}
 
     - name: Unit tests
       if: steps.upstream.outputs.merge_needed == 'true'

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -117,7 +117,12 @@ jobs:
 
     - name: ccache stats
       if: always() && steps.upstream.outputs.merge_needed == 'true'
-      run: ccache -s
+      run: |
+        if command -v ccache >/dev/null; then
+          ccache -s
+        else
+          echo "ccache not installed (earlier steps skipped), skipping stats"
+        fi
 
     - name: Check ccache has data
       id: ccache_has_data
@@ -319,7 +324,12 @@ jobs:
 
     - name: ccache stats
       if: always() && steps.upstream.outputs.merge_needed == 'true'
-      run: ccache -s
+      run: |
+        if command -v ccache >/dev/null; then
+          ccache -s
+        else
+          echo "ccache not installed (earlier steps skipped), skipping stats"
+        fi
 
     - name: Check ccache has data
       id: ccache_has_data

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -8,7 +8,6 @@ on:
 permissions:
   contents: write
   actions: write
-  workflows: write
 
 jobs:
   _master:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   actions: write
+  workflows: write
 
 jobs:
   _master:


### PR DESCRIPTION
## Summary

All `_3-3-5` jobs in the scheduled `merge` workflow were failing (including plain `3.3.5`), while `_master` and upstream TrinityCore `3.3.5` CI stayed green.

The failure was a toolchain mismatch: `_3-3-5` still ran on `ubuntu-22.04` with `gcc-11`, which cannot compile upstream's C++20 `std::ranges::find_if` usage in `Item.cpp` (vendor sell price / used charges).

## Changes

- Runner: `ubuntu-22.04` → `ubuntu-24.04`
- Compiler: `g++-11` → `clang-17` (same as `_master`)
- Dependencies: match `_master` boost/ssl package list
- ccache keys: `ccache-335-*` → `ccache-335-u24-*` so old gcc-11 objects are not reused

## Test plan

- [ ] Confirm `_3-3-5 (3.3.5, ON)` and `(OFF)` go green on this branch / after merge
- [ ] Confirm remaining `*_3.3.5` jobs no longer fail on the shared `Item.cpp` ranges error
