### PR TITLE
Fix reforging_3.3.5 MSVC signed/unsigned warning as error

### DIFF
--- a/src/server/scripts/Custom/Reforging/Reforger.cpp
+++ b/src/server/scripts/Custom/Reforging/Reforger.cpp
@@ -377,7 +377,7 @@ public:
                                 bool cont = false;
                                 for (uint32 j = 0; j < pProto->StatsCount; ++j)
                                 {
-                                    if (statTypes[i] == pProto->ItemStat[j].ItemStatType) // skip existing stats on item
+                                    if (uint32(statTypes[i]) == pProto->ItemStat[j].ItemStatType) // skip existing stats on item
                                     {
                                         cont = true;
                                         break;


### PR DESCRIPTION
## Summary

Windows CI (`Windows x64`) fails on `reforging_3.3.5` because MSVC treats warning **C4389** (signed/unsigned mismatch) as an error under `-WX`.

## What was wrong

In `Reforger.cpp`, the gossip menu compared `ItemModType statTypes[i]` (signed enum) to `ItemStat[j].ItemStatType` (`uint32`):

```text
Reforger.cpp(380): warning C4389: '==': signed/unsigned mismatch
Reforger.cpp(380): error C2220: the following warning is treated as an error
```

Seen in https://github.com/Rochet2/TrinityCore/actions/runs/30409532099/job/90442355993

## Fix

Cast `statTypes[i]` to `uint32` for the comparison.

## Verification

- Built `src/server/scripts/scripts.vcxproj` (Debug) locally — clean.

## Test plan

- [x] Confirm Windows x64 workflow is green on `reforging_3.3.5`.
- [ ] Smoke-test reforger gossip "stat to increase" menu still skips stats already on the item.
