### PR TITLE
Fix gomove_master build after upstream master merge

### DIFF
--- a/src/server/game/Entities/Corpse/Corpse.cpp
+++ b/src/server/game/Entities/Corpse/Corpse.cpp
@@ -88,8 +88,6 @@ bool Corpse::Create(ObjectGuid::LowType guidlow, Player* owner)
     SetObjectScale(1.0f);
     SetOwnerGUID(owner->GetGUID());
 
-    _cellCoord = Trinity::ComputeCellCoord(GetPositionX(), GetPositionY());
-
     PhasingHandler::InheritPhaseShift(this, owner);
 
     return true;
@@ -224,7 +222,6 @@ bool Corpse::LoadCorpseFromDB(ObjectGuid::LowType guid, Field* fields)
         return false;
     }
 
-    _cellCoord = Trinity::ComputeCellCoord(GetPositionX(), GetPositionY());
     return true;
 }
 

--- a/src/server/game/Entities/Corpse/Corpse.h
+++ b/src/server/game/Entities/Corpse/Corpse.h
@@ -126,9 +126,6 @@ class TC_GAME_API Corpse final : public WorldObject, public GridObject<Corpse>
         void ResetGhostTime();
         CorpseType GetType() const { return m_type; }
 
-        CellCoord const& GetCellCoord() const { return _cellCoord; }
-        void SetCellCoord(CellCoord const& cellCoord) { _cellCoord = cellCoord; }
-
         std::unique_ptr<Loot> m_loot;
         Loot* GetLootForPlayer(Player const* /*player*/) const override { return m_loot.get(); }
 
@@ -141,6 +138,5 @@ class TC_GAME_API Corpse final : public WorldObject, public GridObject<Corpse>
     private:
         CorpseType m_type;
         time_t m_time;
-        CellCoord _cellCoord;
 };
 #endif

--- a/src/server/game/Entities/GameObject/GOMove.cpp
+++ b/src/server/game/Entities/GameObject/GOMove.cpp
@@ -209,6 +209,6 @@ std::list<GameObject*> GOMove::GetNearbyGameObjects(Player* player, float range)
     std::list<GameObject*> objects;
     Trinity::GameObjectInRangeCheck check(x, y, z, range);
     Trinity::GameObjectListSearcher<Trinity::GameObjectInRangeCheck> searcher(player, objects, check);
-    Cell::VisitGridObjects(player, searcher, SIZE_OF_GRIDS, false);
+    Cell::VisitGridObjects(player, searcher, SIZE_OF_GRIDS);
     return objects;
 }

--- a/src/server/game/Entities/Transport/Transport.cpp
+++ b/src/server/game/Entities/Transport/Transport.cpp
@@ -550,11 +550,11 @@ void Transport::LoadStaticPassengers()
     if (!mapId)
         return;
 
-    CellObjectGuidsMap const* cells = sObjectMgr->GetMapObjectGuids(mapId, GetMap()->GetDifficultyID());
-    if (!cells)
+    GridObjectGuidsMap const* grids = sObjectMgr->GetMapObjectGuids(mapId, GetMap()->GetDifficultyID());
+    if (!grids)
         return;
 
-    for (auto const& [cellId, guids] : *cells)
+    for (auto const& [gridId, guids] : *grids)
     {
         // GameObjects on transport
         for (ObjectGuid::LowType spawnId : guids.gameobjects)

--- a/src/server/game/Garrison/Garrison.cpp
+++ b/src/server/game/Garrison/Garrison.cpp
@@ -737,9 +737,9 @@ GameObject* Garrison::Plot::CreateGameObject(Map* map, GarrisonFactionIndex fact
 
     if (building->GetGoType() == GAMEOBJECT_TYPE_GARRISON_BUILDING && building->GetGOInfo()->garrisonBuilding.SpawnMap)
     {
-        if (CellObjectGuidsMap const* cells = sObjectMgr->GetMapObjectGuids(building->GetGOInfo()->garrisonBuilding.SpawnMap, map->GetDifficultyID()))
+        if (GridObjectGuidsMap const* grids = sObjectMgr->GetMapObjectGuids(building->GetGOInfo()->garrisonBuilding.SpawnMap, map->GetDifficultyID()))
         {
-            for (auto const& [cellId, guids] : *cells)
+            for (auto const& [gridId, guids] : *grids)
             {
                 for (ObjectGuid::LowType spawnId : guids.gameobjects)
                     if (GameObject* spawn = BuildingSpawnHelper<GameObject, &GameObject::RelocateStationaryPosition>(building, spawnId, map))

--- a/src/server/game/Garrison/GarrisonMap.cpp
+++ b/src/server/game/Garrison/GarrisonMap.cpp
@@ -28,20 +28,13 @@
 class GarrisonGridLoader
 {
 public:
-    GarrisonGridLoader(NGridType* grid, GarrisonMap* map, Cell const& cell)
-        : i_cell(cell), i_grid(grid), i_map(map), i_garrison(map->GetGarrison()), i_gameObjects(0), i_creatures(0)
+    GarrisonGridLoader(NGridType* grid, GarrisonMap* map)
+        : i_grid(grid), i_map(map), i_garrison(map->GetGarrison()), i_gameObjects(0), i_creatures(0)
     { }
-
-    void Visit(GameObjectMapType& m);
-    void Visit(CreatureMapType& m);
 
     void LoadN();
 
-    template<class T> static void SetObjectCell(T* obj, CellCoord const& cellCoord);
-    template<class T> void Visit(GridRefManager<T>& /*m*/) { }
-
 private:
-    Cell i_cell;
     NGridType* i_grid;
     GarrisonMap* i_map;
     Garrison* i_garrison;
@@ -53,51 +46,17 @@ void GarrisonGridLoader::LoadN()
 {
     if (i_garrison)
     {
-        i_cell.data.Part.cell_y = 0;
-        for (uint32 x = 0; x < MAX_NUMBER_OF_CELLS; ++x)
+        for (Garrison::Plot* plot : i_garrison->GetPlots())
         {
-            i_cell.data.Part.cell_x = x;
-            for (uint32 y = 0; y < MAX_NUMBER_OF_CELLS; ++y)
-            {
-                i_cell.data.Part.cell_y = y;
-
-                //Load creatures and game objects
-                TypeContainerVisitor<GarrisonGridLoader, GridTypeMapContainer> visitor(*this);
-                i_grid->VisitGrid(x, y, visitor);
-            }
-        }
-    }
-
-    TC_LOG_DEBUG("maps", "{} GameObjects and {} Creatures loaded for grid {} on map {}", i_gameObjects, i_creatures, i_grid->GetGridId(), i_map->GetId());
-}
-
-void GarrisonGridLoader::Visit(GameObjectMapType& m)
-{
-    std::vector<Garrison::Plot*> plots = i_garrison->GetPlots();
-    if (!plots.empty())
-    {
-        CellCoord cellCoord = i_cell.GetCellCoord();
-        for (Garrison::Plot* plot : plots)
-        {
-            Position const& spawn = plot->PacketInfo.PlotPos.Pos;
-            if (cellCoord != Trinity::ComputeCellCoord(spawn.GetPositionX(), spawn.GetPositionY()))
-                continue;
-
             GameObject* go = plot->CreateGameObject(i_map, i_garrison->GetFaction());
             if (!go)
                 continue;
 
-            go->AddToGrid(m);
-            ObjectGridLoader::SetObjectCell(go, cellCoord);
-            go->AddToWorld();
-            ++i_gameObjects;
+            ObjectGridLoaderBase::AddToMap(go, i_map, i_gameObjects);
         }
     }
-}
 
-void GarrisonGridLoader::Visit(CreatureMapType& /*m*/)
-{
-
+    TC_LOG_DEBUG("maps", "{} GameObjects and {} Creatures loaded for grid {} on map {}", i_gameObjects, i_creatures, i_grid->GetGridId(), i_map->GetId());
 }
 
 GarrisonMap::GarrisonMap(uint32 id, time_t expiry, uint32 instanceId, ObjectGuid const& owner)
@@ -106,11 +65,11 @@ GarrisonMap::GarrisonMap(uint32 id, time_t expiry, uint32 instanceId, ObjectGuid
     GarrisonMap::InitVisibilityDistance();
 }
 
-void GarrisonMap::LoadGridObjects(NGridType* grid, Cell const& cell)
+void GarrisonMap::LoadGridObjects(NGridType* grid)
 {
-    Map::LoadGridObjects(grid, cell);
+    Map::LoadGridObjects(grid);
 
-    GarrisonGridLoader loader(grid, this, cell);
+    GarrisonGridLoader loader(grid, this);
     loader.LoadN();
 }
 

--- a/src/server/game/Garrison/GarrisonMap.h
+++ b/src/server/game/Garrison/GarrisonMap.h
@@ -28,7 +28,7 @@ class TC_GAME_API GarrisonMap : public Map
 public:
     GarrisonMap(uint32 id, time_t, uint32 instanceId, ObjectGuid const& owner);
 
-    void LoadGridObjects(NGridType* grid, Cell const& cell) override;
+    void LoadGridObjects(NGridType* grid) override;
     Garrison* GetGarrison();
 
     void InitVisibilityDistance() override;

--- a/src/server/game/Globals/AreaTriggerDataStore.cpp
+++ b/src/server/game/Globals/AreaTriggerDataStore.cpp
@@ -43,7 +43,7 @@ struct std::hash<AreaTriggerId>
 
 namespace
 {
-    typedef std::unordered_map<uint32/*cell_id*/, std::set<ObjectGuid::LowType>> AtCellObjectGuidsMap;
+    typedef std::unordered_map<uint32/*grid_id*/, Trinity::Containers::FlatSet<ObjectGuid::LowType>> AtCellObjectGuidsMap;
     typedef std::unordered_map<std::pair<uint32 /*mapId*/, Difficulty>, AtCellObjectGuidsMap> AtMapObjectGuids;
 
     AtMapObjectGuids _areaTriggerSpawnsByLocation;
@@ -443,9 +443,9 @@ void AreaTriggerDataStore::LoadAreaTriggerSpawns()
             spawn.spawnGroupData = sObjectMgr->GetLegacySpawnGroup();
 
             // Add the trigger to a map::cell map, which is later used by GridLoader to query
-            CellCoord cellCoord = Trinity::ComputeCellCoord(spawn.spawnPoint.GetPositionX(), spawn.spawnPoint.GetPositionY());
+            GridCoord gridCoord = Trinity::ComputeGridCoord(spawn.spawnPoint.GetPositionX(), spawn.spawnPoint.GetPositionY());
             for (Difficulty difficulty : difficulties)
-                _areaTriggerSpawnsByLocation[{ spawn.mapId, difficulty }][cellCoord.GetId()].insert(spawnId);
+                _areaTriggerSpawnsByLocation[{ spawn.mapId, difficulty }][gridCoord.GetId()].insert(spawnId);
         } while (templates->NextRow());
     }
 
@@ -462,10 +462,10 @@ AreaTriggerCreateProperties const* AreaTriggerDataStore::GetAreaTriggerCreatePro
     return Trinity::Containers::MapGetValuePtr(_areaTriggerCreateProperties, areaTriggerCreatePropertiesId);
 }
 
-std::set<ObjectGuid::LowType> const* AreaTriggerDataStore::GetAreaTriggersForMapAndCell(uint32 mapId, Difficulty difficulty, uint32 cellId) const
+Trinity::Containers::FlatSet<ObjectGuid::LowType> const* AreaTriggerDataStore::GetAreaTriggersForMapAndGrid(uint32 mapId, Difficulty difficulty, uint32 gridId) const
 {
     if (auto* atForMapAndDifficulty = Trinity::Containers::MapGetValuePtr(_areaTriggerSpawnsByLocation, { mapId, difficulty }))
-        return Trinity::Containers::MapGetValuePtr(*atForMapAndDifficulty, cellId);
+        return Trinity::Containers::MapGetValuePtr(*atForMapAndDifficulty, gridId);
 
     return nullptr;
 }

--- a/src/server/game/Globals/AreaTriggerDataStore.h
+++ b/src/server/game/Globals/AreaTriggerDataStore.h
@@ -19,8 +19,8 @@
 #define AreaTriggerDataStore_h__
 
 #include "Define.h"
+#include "FlatSet.h"
 #include "ObjectGuid.h"
-#include <set>
 
 class AreaTriggerTemplate;
 class AreaTriggerCreateProperties;
@@ -36,7 +36,7 @@ public:
     void LoadAreaTriggerTemplates();
     void LoadAreaTriggerSpawns();
 
-    std::set<ObjectGuid::LowType> const* GetAreaTriggersForMapAndCell(uint32 mapId, Difficulty difficulty, uint32 cellId) const;
+    Trinity::Containers::FlatSet<ObjectGuid::LowType> const* GetAreaTriggersForMapAndGrid(uint32 mapId, Difficulty difficulty, uint32 gridId) const;
     AreaTriggerSpawn const* GetAreaTriggerSpawn(ObjectGuid::LowType spawnId) const;
     AreaTriggerTemplate const* GetAreaTriggerTemplate(AreaTriggerId const& areaTriggerId) const;
     AreaTriggerCreateProperties const* GetAreaTriggerCreateProperties(AreaTriggerCreatePropertiesId const& areaTriggerCreatePropertiesId) const;

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -2409,15 +2409,15 @@ void ObjectMgr::LoadCreatures()
     TC_LOG_INFO("server.loading", ">> Loaded {} creatures in {} ms", _creatureDataStore.size(), GetMSTimeDiffToNow(oldMSTime));
 }
 
-CellObjectGuids const* ObjectMgr::GetCellObjectGuids(uint32 mapid, Difficulty spawnMode, uint32 cell_id)
+GridObjectGuids const* ObjectMgr::GetGridObjectGuids(uint32 mapid, Difficulty spawnMode, uint32 gridId)
 {
-    if (CellObjectGuidsMap const* mapGuids = Trinity::Containers::MapGetValuePtr(_mapObjectGuidsStore, { mapid, spawnMode }))
-        return Trinity::Containers::MapGetValuePtr(*mapGuids, cell_id);
+    if (GridObjectGuidsMap const* mapGuids = Trinity::Containers::MapGetValuePtr(_mapObjectGuidsStore, { mapid, spawnMode }))
+        return Trinity::Containers::MapGetValuePtr(*mapGuids, gridId);
 
     return nullptr;
 }
 
-CellObjectGuidsMap const* ObjectMgr::GetMapObjectGuids(uint32 mapid, Difficulty spawnMode)
+GridObjectGuidsMap const* ObjectMgr::GetMapObjectGuids(uint32 mapid, Difficulty spawnMode)
 {
     return Trinity::Containers::MapGetValuePtr(_mapObjectGuidsStore, { mapid, spawnMode });
 }
@@ -2427,56 +2427,54 @@ bool ObjectMgr::HasPersonalSpawns(uint32 mapid, Difficulty spawnMode, uint32 pha
     return Trinity::Containers::MapGetValuePtr(_mapPersonalObjectGuidsStore, { mapid, spawnMode, phaseId }) != nullptr;
 }
 
-CellObjectGuids const* ObjectMgr::GetCellPersonalObjectGuids(uint32 mapid, Difficulty spawnMode, uint32 phaseId, uint32 cell_id) const
+GridObjectGuids const* ObjectMgr::GetCellPersonalObjectGuids(uint32 mapid, Difficulty spawnMode, uint32 phaseId, uint32 gridId) const
 {
-    if (CellObjectGuidsMap const* guids = Trinity::Containers::MapGetValuePtr(_mapPersonalObjectGuidsStore, { mapid, spawnMode, phaseId }))
-        return Trinity::Containers::MapGetValuePtr(*guids, cell_id);
+    if (GridObjectGuidsMap const* guids = Trinity::Containers::MapGetValuePtr(_mapPersonalObjectGuidsStore, { mapid, spawnMode, phaseId }))
+        return Trinity::Containers::MapGetValuePtr(*guids, gridId);
 
     return nullptr;
 }
 
-template<CellGuidSet CellObjectGuids::*guids>
+template<GridGuidSet GridObjectGuids::*guids>
 void ObjectMgr::AddSpawnDataToGrid(SpawnData const* data)
 {
-    uint32 cellId = Trinity::ComputeCellCoord(data->spawnPoint.GetPositionX(), data->spawnPoint.GetPositionY()).GetId();
-    bool isPersonalPhase = PhasingHandler::IsPersonalPhase(data->phaseId);
-    if (!isPersonalPhase)
+    uint32 gridId = Trinity::ComputeGridCoord(data->spawnPoint.GetPositionX(), data->spawnPoint.GetPositionY()).GetId();
+    if (!PhasingHandler::IsPersonalPhase(data->phaseId))
     {
         for (Difficulty difficulty : data->spawnDifficulties)
-            (_mapObjectGuidsStore[{ data->mapId, difficulty }][cellId].*guids).insert(data->spawnId);
+            (_mapObjectGuidsStore[{ data->mapId, difficulty }][gridId].*guids).insert(data->spawnId);
     }
     else
     {
         for (Difficulty difficulty : data->spawnDifficulties)
-            (_mapPersonalObjectGuidsStore[{ data->mapId, difficulty, data->phaseId }][cellId].*guids).insert(data->spawnId);
+            (_mapPersonalObjectGuidsStore[{ data->mapId, difficulty, data->phaseId }][gridId].*guids).insert(data->spawnId);
     }
 }
 
-template<CellGuidSet CellObjectGuids::*guids>
+template<GridGuidSet GridObjectGuids::*guids>
 void ObjectMgr::RemoveSpawnDataFromGrid(SpawnData const* data)
 {
-    uint32 cellId = Trinity::ComputeCellCoord(data->spawnPoint.GetPositionX(), data->spawnPoint.GetPositionY()).GetId();
-    bool isPersonalPhase = PhasingHandler::IsPersonalPhase(data->phaseId);
-    if (!isPersonalPhase)
+    uint32 gridId = Trinity::ComputeGridCoord(data->spawnPoint.GetPositionX(), data->spawnPoint.GetPositionY()).GetId();
+    if (!PhasingHandler::IsPersonalPhase(data->phaseId))
     {
         for (Difficulty difficulty : data->spawnDifficulties)
-            (_mapObjectGuidsStore[{ data->mapId, difficulty }][cellId].*guids).erase(data->spawnId);
+            (_mapObjectGuidsStore[{ data->mapId, difficulty }][gridId].*guids).erase(data->spawnId);
     }
     else
     {
         for (Difficulty difficulty : data->spawnDifficulties)
-            (_mapPersonalObjectGuidsStore[{ data->mapId, difficulty, data->phaseId }][cellId].*guids).erase(data->spawnId);
+            (_mapPersonalObjectGuidsStore[{ data->mapId, difficulty, data->phaseId }][gridId].*guids).erase(data->spawnId);
     }
 }
 
 void ObjectMgr::AddCreatureToGrid(CreatureData const* data)
 {
-    AddSpawnDataToGrid<&CellObjectGuids::creatures>(data);
+    AddSpawnDataToGrid<&GridObjectGuids::creatures>(data);
 }
 
 void ObjectMgr::RemoveCreatureFromGrid(CreatureData const* data)
 {
-    RemoveSpawnDataFromGrid<&CellObjectGuids::creatures>(data);
+    RemoveSpawnDataFromGrid<&GridObjectGuids::creatures>(data);
 }
 
 void ObjectMgr::LoadGameObjects()
@@ -2976,12 +2974,12 @@ void ObjectMgr::OnDeleteSpawnData(SpawnData const* data)
 
 void ObjectMgr::AddGameobjectToGrid(GameObjectData const* data)
 {
-    AddSpawnDataToGrid<&CellObjectGuids::gameobjects>(data);
+    AddSpawnDataToGrid<&GridObjectGuids::gameobjects>(data);
 }
 
 void ObjectMgr::RemoveGameobjectFromGrid(GameObjectData const* data)
 {
-    RemoveSpawnDataFromGrid<&CellObjectGuids::gameobjects>(data);
+    RemoveSpawnDataFromGrid<&GridObjectGuids::gameobjects>(data);
 }
 
 uint32 FillMaxDurability(uint32 itemClass, uint32 itemSubClass, uint32 inventoryType, uint32 quality, uint32 itemLevel)

--- a/src/server/game/Globals/ObjectMgr.h
+++ b/src/server/game/Globals/ObjectMgr.h
@@ -22,6 +22,7 @@
 #include "ConditionMgr.h"
 #include "CreatureData.h"
 #include "DatabaseEnvFwd.h"
+#include "FlatSet.h"
 #include "GameObjectData.h"
 #include "ItemTemplate.h"
 #include "IteratorPair.h"
@@ -467,15 +468,15 @@ struct AccessRequirement
     std::string questFailedText;
 };
 
-typedef std::set<ObjectGuid::LowType> CellGuidSet;
-struct CellObjectGuids
+typedef Trinity::Containers::FlatSet<ObjectGuid::LowType> GridGuidSet;
+struct GridObjectGuids
 {
-    CellGuidSet creatures;
-    CellGuidSet gameobjects;
+    GridGuidSet creatures;
+    GridGuidSet gameobjects;
 };
-typedef std::unordered_map<uint32/*cell_id*/, CellObjectGuids> CellObjectGuidsMap;
-typedef std::unordered_map<std::pair<uint32 /*mapId*/, Difficulty>, CellObjectGuidsMap> MapObjectGuids;
-typedef std::map<std::tuple<uint32/*mapId*/, Difficulty, uint32 /*phaseId*/>, CellObjectGuidsMap> MapPersonalObjectGuids;
+typedef std::unordered_map<uint32/*grid_id*/, GridObjectGuids> GridObjectGuidsMap;
+typedef std::unordered_map<std::pair<uint32 /*mapId*/, Difficulty>, GridObjectGuidsMap> MapObjectGuids;
+typedef std::map<std::tuple<uint32/*mapId*/, Difficulty, uint32 /*phaseId*/>, GridObjectGuidsMap> MapPersonalObjectGuids;
 
 struct TrinityString
 {
@@ -1383,12 +1384,12 @@ class TC_GAME_API ObjectMgr
             return nullptr;
         }
 
-        CellObjectGuids const* GetCellObjectGuids(uint32 mapid, Difficulty spawnMode, uint32 cell_id);
+        GridObjectGuids const* GetGridObjectGuids(uint32 mapid, Difficulty spawnMode, uint32 gridId);
 
-        CellObjectGuidsMap const* GetMapObjectGuids(uint32 mapid, Difficulty spawnMode);
+        GridObjectGuidsMap const* GetMapObjectGuids(uint32 mapid, Difficulty spawnMode);
 
         bool HasPersonalSpawns(uint32 mapid, Difficulty spawnMode, uint32 phaseId) const;
-        CellObjectGuids const* GetCellPersonalObjectGuids(uint32 mapid, Difficulty spawnMode, uint32 phaseId, uint32 cell_id) const;
+        GridObjectGuids const* GetCellPersonalObjectGuids(uint32 mapid, Difficulty spawnMode, uint32 phaseId, uint32 gridId) const;
 
         /**
          * Gets temp summon data for all creatures of specified group.
@@ -1777,10 +1778,10 @@ class TC_GAME_API ObjectMgr
         QuestRelationResult GetQuestRelationsFrom(QuestRelations const& map, uint32 key, bool onlyActive) const { return { map.equal_range(key), onlyActive }; }
         void PlayerCreateInfoAddItemHelper(uint32 race_, uint32 class_, uint32 itemId, int32 count);
 
-        template<CellGuidSet CellObjectGuids::*guids>
+        template<GridGuidSet GridObjectGuids::*guids>
         void AddSpawnDataToGrid(SpawnData const* data);
 
-        template<CellGuidSet CellObjectGuids::*guids>
+        template<GridGuidSet GridObjectGuids::*guids>
         void RemoveSpawnDataFromGrid(SpawnData const* data);
 
         MailLevelRewardContainer _mailLevelRewardStore;

--- a/src/server/game/Grids/Cells/Cell.h
+++ b/src/server/game/Grids/Cells/Cell.h
@@ -28,16 +28,7 @@ class WorldObject;
 
 struct CellArea
 {
-    CellArea() { }
     CellArea(CellCoord low, CellCoord high) : low_bound(low), high_bound(high) { }
-
-    bool operator!() const { return low_bound == high_bound; }
-
-    void ResizeBorders(CellCoord& begin_cell, CellCoord& end_cell) const
-    {
-        begin_cell = low_bound;
-        end_cell = high_bound;
-    }
 
     CellCoord low_bound;
     CellCoord high_bound;

--- a/src/server/game/Grids/Cells/Cell.h
+++ b/src/server/game/Grids/Cells/Cell.h
@@ -62,8 +62,13 @@ struct Cell
     uint32 CellY() const { return data.Part.cell_y; }
     uint32 GridX() const { return data.Part.grid_x; }
     uint32 GridY() const { return data.Part.grid_y; }
-    bool NoCreate() const { return data.Part.nocreate; }
-    void SetNoCreate() { data.Part.nocreate = 1; }
+
+    GridCoord GetGridCoord() const
+    {
+        return GridCoord(
+            data.Part.grid_x,
+            data.Part.grid_y);
+    }
 
     CellCoord GetCellCoord() const
     {
@@ -81,9 +86,8 @@ struct Cell
             uint8 grid_y;
             uint8 cell_x;
             uint8 cell_y;
-            uint8 nocreate;
         } Part;
-        uint64 All;
+        uint32 All;
     } data;
 
     template<class T, class CONTAINER> void Visit(CellCoord const&, TypeContainerVisitor<T, CONTAINER>& visitor, Map&, WorldObject const& obj, float radius) const;
@@ -91,13 +95,13 @@ struct Cell
 
     static CellArea CalculateCellArea(float x, float y, float radius);
 
-    template<class T> static void VisitGridObjects(WorldObject const* obj, T& visitor, float radius, bool dont_load = true);
-    template<class T> static void VisitWorldObjects(WorldObject const* obj, T& visitor, float radius, bool dont_load = true);
-    template<class T> static void VisitAllObjects(WorldObject const* obj, T& visitor, float radius, bool dont_load = true);
+    template<class T> static void VisitGridObjects(WorldObject const* obj, T& visitor, float radius);
+    template<class T> static void VisitWorldObjects(WorldObject const* obj, T& visitor, float radius);
+    template<class T> static void VisitAllObjects(WorldObject const* obj, T& visitor, float radius);
 
-    template<class T> static void VisitGridObjects(float x, float y, Map* map, T& visitor, float radius, bool dont_load = true);
-    template<class T> static void VisitWorldObjects(float x, float y, Map* map, T& visitor, float radius, bool dont_load = true);
-    template<class T> static void VisitAllObjects(float x, float y, Map* map, T& visitor, float radius, bool dont_load = true);
+    template<class T> static void VisitGridObjects(float x, float y, Map* map, T& visitor, float radius);
+    template<class T> static void VisitWorldObjects(float x, float y, Map* map, T& visitor, float radius);
+    template<class T> static void VisitAllObjects(float x, float y, Map* map, T& visitor, float radius);
 
 private:
     template<class T, class CONTAINER> void VisitCircle(TypeContainerVisitor<T, CONTAINER> &, Map &, CellCoord const&, CellCoord const&) const;

--- a/src/server/game/Grids/Cells/CellImpl.h
+++ b/src/server/game/Grids/Cells/CellImpl.h
@@ -82,7 +82,6 @@ inline void Cell::Visit(CellCoord const& standing_cell, TypeContainerVisitor<T, 
         {
             CellCoord cellCoord(x, y);
             Cell r_zone(cellCoord);
-            r_zone.data.Part.nocreate = this->data.Part.nocreate;
             map.Visit(r_zone, visitor);
         }
     }
@@ -104,7 +103,6 @@ inline void Cell::VisitCircle(TypeContainerVisitor<T, CONTAINER>& visitor, Map& 
         {
             CellCoord cellCoord(x, y);
             Cell r_zone(cellCoord);
-            r_zone.data.Part.nocreate = this->data.Part.nocreate;
             map.Visit(r_zone, visitor);
         }
     }
@@ -128,49 +126,41 @@ inline void Cell::VisitCircle(TypeContainerVisitor<T, CONTAINER>& visitor, Map& 
             //e.g. filling 2 trapezoids after filling central cell strip...
             CellCoord cellCoord_left(x_start - step, y);
             Cell r_zone_left(cellCoord_left);
-            r_zone_left.data.Part.nocreate = this->data.Part.nocreate;
             map.Visit(r_zone_left, visitor);
 
             //right trapezoid cell visit
             CellCoord cellCoord_right(x_end + step, y);
             Cell r_zone_right(cellCoord_right);
-            r_zone_right.data.Part.nocreate = this->data.Part.nocreate;
             map.Visit(r_zone_right, visitor);
         }
     }
 }
 
 template<class T>
-inline void Cell::VisitGridObjects(WorldObject const* center_obj, T& visitor, float radius, bool dont_load)
+inline void Cell::VisitGridObjects(WorldObject const* center_obj, T& visitor, float radius)
 {
     CellCoord p(Trinity::ComputeCellCoord(center_obj->GetPositionX(), center_obj->GetPositionY()));
     Cell cell(p);
-    if (dont_load)
-        cell.SetNoCreate();
 
     TypeContainerVisitor<T, GridTypeMapContainer> gnotifier(visitor);
     cell.Visit(p, gnotifier, *center_obj->GetMap(), *center_obj, radius);
 }
 
 template<class T>
-inline void Cell::VisitWorldObjects(WorldObject const* center_obj, T& visitor, float radius, bool dont_load)
+inline void Cell::VisitWorldObjects(WorldObject const* center_obj, T& visitor, float radius)
 {
     CellCoord p(Trinity::ComputeCellCoord(center_obj->GetPositionX(), center_obj->GetPositionY()));
     Cell cell(p);
-    if (dont_load)
-        cell.SetNoCreate();
 
     TypeContainerVisitor<T, WorldTypeMapContainer> gnotifier(visitor);
     cell.Visit(p, gnotifier, *center_obj->GetMap(), *center_obj, radius);
 }
 
 template<class T>
-inline void Cell::VisitAllObjects(WorldObject const* center_obj, T& visitor, float radius, bool dont_load)
+inline void Cell::VisitAllObjects(WorldObject const* center_obj, T& visitor, float radius)
 {
     CellCoord p(Trinity::ComputeCellCoord(center_obj->GetPositionX(), center_obj->GetPositionY()));
     Cell cell(p);
-    if (dont_load)
-        cell.SetNoCreate();
 
     TypeContainerVisitor<T, WorldTypeMapContainer> wnotifier(visitor);
     cell.Visit(p, wnotifier, *center_obj->GetMap(), *center_obj, radius);
@@ -179,36 +169,30 @@ inline void Cell::VisitAllObjects(WorldObject const* center_obj, T& visitor, flo
 }
 
 template<class T>
-inline void Cell::VisitGridObjects(float x, float y, Map* map, T& visitor, float radius, bool dont_load)
+inline void Cell::VisitGridObjects(float x, float y, Map* map, T& visitor, float radius)
 {
     CellCoord p(Trinity::ComputeCellCoord(x, y));
     Cell cell(p);
-    if (dont_load)
-        cell.SetNoCreate();
 
     TypeContainerVisitor<T, GridTypeMapContainer> gnotifier(visitor);
     cell.Visit(p, gnotifier, *map, x, y, radius);
 }
 
 template<class T>
-inline void Cell::VisitWorldObjects(float x, float y, Map* map, T& visitor, float radius, bool dont_load)
+inline void Cell::VisitWorldObjects(float x, float y, Map* map, T& visitor, float radius)
 {
     CellCoord p(Trinity::ComputeCellCoord(x, y));
     Cell cell(p);
-    if (dont_load)
-        cell.SetNoCreate();
 
     TypeContainerVisitor<T, WorldTypeMapContainer> gnotifier(visitor);
     cell.Visit(p, gnotifier, *map, x, y, radius);
 }
 
 template<class T>
-inline void Cell::VisitAllObjects(float x, float y, Map* map, T& visitor, float radius, bool dont_load)
+inline void Cell::VisitAllObjects(float x, float y, Map* map, T& visitor, float radius)
 {
     CellCoord p(Trinity::ComputeCellCoord(x, y));
     Cell cell(p);
-    if (dont_load)
-        cell.SetNoCreate();
 
     TypeContainerVisitor<T, WorldTypeMapContainer> wnotifier(visitor);
     cell.Visit(p, wnotifier, *map, x, y, radius);

--- a/src/server/game/Grids/Cells/CellImpl.h
+++ b/src/server/game/Grids/Cells/CellImpl.h
@@ -58,26 +58,12 @@ inline void Cell::Visit(CellCoord const& standing_cell, TypeContainerVisitor<T, 
     if (!standing_cell.IsCoordValid())
         return;
 
-    //no jokes here... Actually placing ASSERT() here was good idea, but
-    //we had some problems with DynamicObjects, which pass radius = 0.0f (DB issue?)
-    //maybe it is better to just return when radius <= 0.0f?
-    if (radius <= 0.0f)
-    {
-        map.Visit(*this, visitor);
-        return;
-    }
     //lets limit the upper value for search radius
     if (radius > SIZE_OF_GRIDS)
         radius = SIZE_OF_GRIDS;
 
     //lets calculate object coord offsets from cell borders.
     CellArea area = Cell::CalculateCellArea(x_off, y_off, radius);
-    //if radius fits inside standing cell
-    if (!area)
-    {
-        map.Visit(*this, visitor);
-        return;
-    }
 
     //visit all cells, found in CalculateCellArea()
     //if radius is known to reach cell area more than 4x4 then we should call optimized VisitCircle
@@ -89,23 +75,15 @@ inline void Cell::Visit(CellCoord const& standing_cell, TypeContainerVisitor<T, 
         return;
     }
 
-    //ALWAYS visit standing cell first!!! Since we deal with small radiuses
-    //it is very essential to call visitor for standing cell firstly...
-    map.Visit(*this, visitor);
-
     // loop the cell range
     for (uint32 x = area.low_bound.x_coord; x <= area.high_bound.x_coord; ++x)
     {
         for (uint32 y = area.low_bound.y_coord; y <= area.high_bound.y_coord; ++y)
         {
             CellCoord cellCoord(x, y);
-            //lets skip standing cell since we already visited it
-            if (cellCoord != standing_cell)
-            {
-                Cell r_zone(cellCoord);
-                r_zone.data.Part.nocreate = this->data.Part.nocreate;
-                map.Visit(r_zone, visitor);
-            }
+            Cell r_zone(cellCoord);
+            r_zone.data.Part.nocreate = this->data.Part.nocreate;
+            map.Visit(r_zone, visitor);
         }
     }
 }

--- a/src/server/game/Grids/Cells/CellImpl.h
+++ b/src/server/game/Grids/Cells/CellImpl.h
@@ -34,12 +34,12 @@ inline CellArea Cell::CalculateCellArea(float x, float y, float radius)
 {
     if (radius <= 0.0f)
     {
-        CellCoord center = Trinity::ComputeCellCoord(x, y).normalize();
+        CellCoord center = Trinity::ComputeCellCoord(x, y);
         return CellArea(center, center);
     }
 
-    CellCoord centerX = Trinity::ComputeCellCoord(x - radius, y - radius).normalize();
-    CellCoord centerY = Trinity::ComputeCellCoord(x + radius, y + radius).normalize();
+    CellCoord centerX = Trinity::ComputeCellCoord(x - radius, y - radius);
+    CellCoord centerY = Trinity::ComputeCellCoord(x + radius, y + radius);
 
     return CellArea(centerX, centerY);
 }

--- a/src/server/game/Grids/GridDefines.h
+++ b/src/server/game/Grids/GridDefines.h
@@ -100,20 +100,9 @@ typedef NGrid<MAX_NUMBER_OF_CELLS, WorldTypeMapContainer, GridTypeMapContainer> 
 template<uint32 LIMIT>
 struct CoordPair
 {
-    CoordPair(uint32 x=0, uint32 y=0)
+    CoordPair(uint32 x, uint32 y)
         : x_coord(x), y_coord(y)
     { }
-
-    CoordPair(const CoordPair<LIMIT> &obj)
-        : x_coord(obj.x_coord), y_coord(obj.y_coord)
-    { }
-
-    CoordPair<LIMIT> & operator=(const CoordPair<LIMIT> &obj)
-    {
-        x_coord = obj.x_coord;
-        y_coord = obj.y_coord;
-        return *this;
-    }
 
     void dec_x(uint32 val)
     {

--- a/src/server/game/Grids/GridDefines.h
+++ b/src/server/game/Grids/GridDefines.h
@@ -100,11 +100,10 @@ typedef NGrid<MAX_NUMBER_OF_CELLS, WorldTypeMapContainer, GridTypeMapContainer> 
 template<uint32 LIMIT>
 struct CoordPair
 {
-    CoordPair(uint32 x, uint32 y)
-        : x_coord(x), y_coord(y)
-    { }
+    constexpr CoordPair(uint32 x, uint32 y)
+        : x_coord(x), y_coord(y) { }
 
-    void dec_x(uint32 val)
+    constexpr void dec_x(uint32 val)
     {
         if (x_coord > val)
             x_coord -= val;
@@ -112,7 +111,7 @@ struct CoordPair
             x_coord = 0;
     }
 
-    void inc_x(uint32 val)
+    constexpr void inc_x(uint32 val)
     {
         if (x_coord + val < LIMIT)
             x_coord += val;
@@ -120,7 +119,7 @@ struct CoordPair
             x_coord = LIMIT - 1;
     }
 
-    void dec_y(uint32 val)
+    constexpr void dec_y(uint32 val)
     {
         if (y_coord > val)
             y_coord -= val;
@@ -128,7 +127,7 @@ struct CoordPair
             y_coord = 0;
     }
 
-    void inc_y(uint32 val)
+    constexpr void inc_y(uint32 val)
     {
         if (y_coord + val < LIMIT)
             y_coord += val;
@@ -136,24 +135,17 @@ struct CoordPair
             y_coord = LIMIT - 1;
     }
 
-    bool IsCoordValid() const
+    constexpr bool IsCoordValid() const
     {
         return x_coord < LIMIT && y_coord < LIMIT;
     }
 
-    CoordPair& normalize()
-    {
-        x_coord = std::min(x_coord, LIMIT - 1);
-        y_coord = std::min(y_coord, LIMIT - 1);
-        return *this;
-    }
-
-    uint32 GetId() const
+    constexpr uint32 GetId() const
     {
         return y_coord * LIMIT + x_coord;
     }
 
-    friend bool operator==(CoordPair const& p1, CoordPair const& p2) = default;
+    friend constexpr bool operator==(CoordPair const& p1, CoordPair const& p2) = default;
 
     uint32 x_coord;
     uint32 y_coord;
@@ -164,48 +156,39 @@ typedef CoordPair<TOTAL_NUMBER_OF_CELLS_PER_MAP> CellCoord;
 
 namespace Trinity
 {
-    template<class RET_TYPE, int CENTER_VAL>
-    inline RET_TYPE Compute(float x, float y, float center_offset, float size)
+    template<int32 LIMIT, int32 CENTER_VAL>
+    inline constexpr CoordPair<LIMIT> Compute(float x, float y, float center_offset, float size)
     {
         // calculate and store temporary values in double format for having same result as same mySQL calculations
-        double x_offset = (double(x) - center_offset)/size;
-        double y_offset = (double(y) - center_offset)/size;
+        double x_offset = (double(x) - center_offset) / size;
+        double y_offset = (double(y) - center_offset) / size;
 
-        int x_val = int(x_offset + CENTER_VAL + 0.5);
-        int y_val = int(y_offset + CENTER_VAL + 0.5);
-        return RET_TYPE(x_val, y_val);
+        int32 x_val = int32(x_offset + CENTER_VAL + 0.5);
+        int32 y_val = int32(y_offset + CENTER_VAL + 0.5);
+        return CoordPair<LIMIT>(
+            x_val >= 0 ? x_val < LIMIT ? x_val : LIMIT - 1 : 0,
+            y_val >= 0 ? y_val < LIMIT ? y_val : LIMIT - 1 : 0
+        );
     }
 
-    inline GridCoord ComputeGridCoord(float x, float y)
+    inline constexpr GridCoord ComputeGridCoord(float x, float y)
     {
-        return Compute<GridCoord, CENTER_GRID_ID>(x, y, CENTER_GRID_OFFSET, SIZE_OF_GRIDS);
+        return Compute<MAX_NUMBER_OF_GRIDS, CENTER_GRID_ID>(x, y, CENTER_GRID_OFFSET, SIZE_OF_GRIDS);
     }
 
-    inline GridCoord ComputeGridCoordSimple(float x, float y)
+    inline constexpr GridCoord ComputeGridCoordSimple(float x, float y)
     {
         int gx = (int)(CENTER_GRID_ID - x / SIZE_OF_GRIDS);
         int gy = (int)(CENTER_GRID_ID - y / SIZE_OF_GRIDS);
         return GridCoord((MAX_NUMBER_OF_GRIDS - 1) - gx, (MAX_NUMBER_OF_GRIDS - 1) - gy);
     }
 
-    inline CellCoord ComputeCellCoord(float x, float y)
+    inline constexpr CellCoord ComputeCellCoord(float x, float y)
     {
-        return Compute<CellCoord, CENTER_GRID_CELL_ID>(x, y, CENTER_GRID_CELL_OFFSET, SIZE_OF_GRID_CELL);
+        return Compute<TOTAL_NUMBER_OF_CELLS_PER_MAP, CENTER_GRID_CELL_ID>(x, y, CENTER_GRID_CELL_OFFSET, SIZE_OF_GRID_CELL);
     }
 
-    inline CellCoord ComputeCellCoord(float x, float y, float &x_off, float &y_off)
-    {
-        double x_offset = (double(x) - CENTER_GRID_CELL_OFFSET)/SIZE_OF_GRID_CELL;
-        double y_offset = (double(y) - CENTER_GRID_CELL_OFFSET)/SIZE_OF_GRID_CELL;
-
-        int x_val = int(x_offset + CENTER_GRID_CELL_ID + 0.5f);
-        int y_val = int(y_offset + CENTER_GRID_CELL_ID + 0.5f);
-        x_off = (float(x_offset) - float(x_val) + CENTER_GRID_CELL_ID) * SIZE_OF_GRID_CELL;
-        y_off = (float(y_offset) - float(y_val) + CENTER_GRID_CELL_ID) * SIZE_OF_GRID_CELL;
-        return CellCoord(x_val, y_val);
-    }
-
-    inline void NormalizeMapCoord(float &c)
+    inline constexpr void NormalizeMapCoord(float &c)
     {
         if (c > MAP_HALFSIZE - 0.5f)
             c = MAP_HALFSIZE - 0.5f;

--- a/src/server/game/Grids/Notifiers/GridNotifiers.cpp
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.cpp
@@ -232,8 +232,10 @@ void DelayedUnitRelocation::Visit(PlayerMapType &m)
         if (player != viewPoint && !viewPoint->IsPositionValid())
             continue;
 
+        i_map.LoadGridsInRange(viewPoint->GetPositionX(), viewPoint->GetPositionY(), i_radius + viewPoint->GetCombatReach());
+
         PlayerRelocationNotifier relocate(*player);
-        Cell::VisitAllObjects(viewPoint, relocate, i_radius, false);
+        Cell::VisitAllObjects(viewPoint, relocate, i_radius);
         relocate.SendToSelf();
     }
 }

--- a/src/server/game/Grids/ObjectGridLoader.cpp
+++ b/src/server/game/Grids/ObjectGridLoader.cpp
@@ -22,12 +22,10 @@
 #include "Conversation.h"
 #include "Corpse.h"
 #include "Creature.h"
-#include "CreatureAI.h"
 #include "DynamicObject.h"
 #include "GameObject.h"
 #include "GameTime.h"
 #include "Log.h"
-#include "ObjectAccessor.h"
 #include "ObjectMgr.h"
 #include "PhasingHandler.h"
 #include "SceneObject.h"
@@ -61,49 +59,24 @@ void ObjectGridEvacuator::Visit(GameObjectMapType &m)
     }
 }
 
-// for loading world object at grid loading (Corpses)
-/// @todo to implement npc on transport, also need to load npcs at grid loading
-class ObjectWorldLoader
-{
-    public:
-        explicit ObjectWorldLoader(ObjectGridLoader& gloader)
-            : i_cell(gloader.i_cell), i_map(gloader.i_map), i_grid(gloader.i_grid), i_corpses(gloader.i_corpses)
-            { }
-
-        void Visit(CorpseMapType &m);
-
-        template<class T> void Visit(GridRefManager<T>&) { }
-
-    private:
-        Cell i_cell;
-        Map* i_map;
-        NGridType& i_grid;
-    public:
-        uint32& i_corpses;
-};
-
-void ObjectGridLoaderBase::SetObjectCell(MapObject* obj, CellCoord const& cellCoord)
-{
-    Cell cell(cellCoord);
-    obj->SetCurrentCell(cell);
-}
-
 template <class T>
-void AddObjectHelper(CellCoord &cell, GridRefManager<T> &m, uint32 &count, Map* map, T *obj)
+void ObjectGridLoaderBase::AddToMap(T* obj, Map* map, uint32& objectCount)
 {
-    obj->AddToGrid(m);
-    ObjectGridLoader::SetObjectCell(obj, cell);
+    CellCoord cellCoord = Trinity::ComputeCellCoord(obj->GetPositionX(), obj->GetPositionY());
+    Cell cell(cellCoord);
+
+    map->AddToGrid<T>(obj, cell);
     obj->AddToWorld();
     if (obj->isActiveObject())
         map->AddToActive(obj);
 
-    ++count;
+    ++objectCount;
 }
 
 template <class T>
-void LoadHelper(CellGuidSet const& guid_set, CellCoord& cell, GridRefManager<T>& m, uint32& count, Map* map, uint32 phaseId = 0, Optional<ObjectGuid> phaseOwner = {})
+void LoadHelper(GridGuidSet const& guid_set, uint32& count, Map* map, uint32 phaseId = 0, Optional<ObjectGuid> phaseOwner = {})
 {
-    for (CellGuidSet::const_iterator i_guid = guid_set.begin(); i_guid != guid_set.end(); ++i_guid)
+    for (GridGuidSet::const_iterator i_guid = guid_set.begin(); i_guid != guid_set.end(); ++i_guid)
     {
         // Don't spawn at all if there's a respawn timer
         ObjectGuid::LowType guid = *i_guid;
@@ -124,108 +97,40 @@ void LoadHelper(CellGuidSet const& guid_set, CellCoord& cell, GridRefManager<T>&
             map->GetMultiPersonalPhaseTracker().RegisterTrackedObject(phaseId, *phaseOwner, obj);
         }
 
-        AddObjectHelper(cell, m, count, map, obj);
+        ObjectGridLoaderBase::AddToMap(obj, map, count);
     }
 }
 
-void ObjectGridLoader::Visit(GameObjectMapType& m)
+void ObjectGridLoader::LoadN()
 {
-    CellCoord cellCoord = i_cell.GetCellCoord();
-    if (CellObjectGuids const* cell_guids = sObjectMgr->GetCellObjectGuids(i_map->GetId(), i_map->GetDifficultyID(), cellCoord.GetId()))
-        LoadHelper(cell_guids->gameobjects, cellCoord, m, i_gameObjects, i_map);
-}
+    i_gameObjects = 0; i_creatures = 0; i_corpses = 0; i_areaTriggers = 0;
 
-void ObjectGridLoader::Visit(CreatureMapType &m)
-{
-    CellCoord cellCoord = i_cell.GetCellCoord();
-    if (CellObjectGuids const* cell_guids = sObjectMgr->GetCellObjectGuids(i_map->GetId(), i_map->GetDifficultyID(), cellCoord.GetId()))
-        LoadHelper(cell_guids->creatures, cellCoord, m, i_creatures, i_map);
-}
-
-void ObjectGridLoader::Visit(AreaTriggerMapType& m)
-{
-    CellCoord cellCoord = i_cell.GetCellCoord();
-    if (CellGuidSet const* areaTriggers = sAreaTriggerDataStore->GetAreaTriggersForMapAndCell(i_map->GetId(), i_map->GetDifficultyID(), cellCoord.GetId()))
-        LoadHelper(*areaTriggers, cellCoord, m, i_areaTriggers, i_map);
-}
-
-void ObjectWorldLoader::Visit(CorpseMapType& /*m*/)
-{
-    CellCoord cellCoord = i_cell.GetCellCoord();
-    if (std::unordered_set<Corpse*> const* corpses = i_map->GetCorpsesInCell(cellCoord.GetId()))
+    //Load creatures and game objects
+    if (GridObjectGuids const* grid_guids = sObjectMgr->GetGridObjectGuids(i_map->GetId(), i_map->GetDifficultyID(), i_grid.GetGridId()))
     {
+        LoadHelper<GameObject>(grid_guids->gameobjects, i_gameObjects, i_map);
+        LoadHelper<Creature>(grid_guids->creatures, i_creatures, i_map);
+    }
+
+    //Load areatriggers
+    if (GridGuidSet const* areaTriggers = sAreaTriggerDataStore->GetAreaTriggersForMapAndGrid(i_map->GetId(), i_map->GetDifficultyID(), i_grid.GetGridId()))
+        LoadHelper<AreaTrigger>(*areaTriggers, i_areaTriggers, i_map);
+
+    //Load corpses (not bones)
+    if (std::unordered_set<Corpse*> const* corpses = i_map->GetCorpsesInGrid(i_grid.GetGridId()))
         for (Corpse* corpse : *corpses)
-        {
-            corpse->AddToWorld();
-            GridType& cell = i_grid.GetGridType(i_cell.CellX(), i_cell.CellY());
-            if (corpse->IsStoredInWorldObjectGridContainer())
-                cell.AddWorldObject(corpse);
-            else
-                cell.AddGridObject(corpse);
+            AddToMap(corpse, i_map, i_corpses);
 
-            ++i_corpses;
-        }
-    }
-}
-
-void ObjectGridLoader::LoadN(void)
-{
-    i_gameObjects = 0; i_creatures = 0; i_corpses = 0;
-    i_cell.data.Part.cell_y = 0;
-    for (uint32 x = 0; x < MAX_NUMBER_OF_CELLS; ++x)
-    {
-        i_cell.data.Part.cell_x = x;
-        for (uint32 y = 0; y < MAX_NUMBER_OF_CELLS; ++y)
-        {
-            i_cell.data.Part.cell_y = y;
-
-            //Load creatures and game objects
-            {
-                TypeContainerVisitor<ObjectGridLoader, GridTypeMapContainer> visitor(*this);
-                i_grid.VisitGrid(x, y, visitor);
-            }
-
-            //Load corpses (not bones)
-            {
-                ObjectWorldLoader worker(*this);
-                TypeContainerVisitor<ObjectWorldLoader, WorldTypeMapContainer> visitor(worker);
-                i_grid.VisitGrid(x, y, visitor);
-            }
-        }
-    }
     TC_LOG_DEBUG("maps", "{} GameObjects, {} Creatures, {} AreaTrriggers, and {} Corpses/Bones loaded for grid {} on map {}",
         i_gameObjects, i_creatures, i_areaTriggers, i_corpses, i_grid.GetGridId(), i_map->GetId());
 }
 
-void PersonalPhaseGridLoader::Visit(GameObjectMapType& m)
-{
-    CellCoord cellCoord = i_cell.GetCellCoord();
-    if (CellObjectGuids const* cell_guids = sObjectMgr->GetCellPersonalObjectGuids(i_map->GetId(), i_map->GetDifficultyID(), _phaseId, cellCoord.GetId()))
-        LoadHelper(cell_guids->gameobjects, cellCoord, m, i_gameObjects, i_map, _phaseId, _phaseOwner);
-}
-
-void PersonalPhaseGridLoader::Visit(CreatureMapType& m)
-{
-    CellCoord cellCoord = i_cell.GetCellCoord();
-    if (CellObjectGuids const* cell_guids = sObjectMgr->GetCellPersonalObjectGuids(i_map->GetId(), i_map->GetDifficultyID(), _phaseId, cellCoord.GetId()))
-        LoadHelper(cell_guids->creatures, cellCoord, m, i_creatures, i_map, _phaseId, _phaseOwner);
-}
-
 void PersonalPhaseGridLoader::Load(uint32 phaseId)
 {
-    _phaseId = phaseId;
-    i_cell.data.Part.cell_y = 0;
-    for (uint32 x = 0; x < MAX_NUMBER_OF_CELLS; ++x)
+    if (GridObjectGuids const* grid_guids = sObjectMgr->GetCellPersonalObjectGuids(i_map->GetId(), i_map->GetDifficultyID(), phaseId, i_grid.GetGridId()))
     {
-        i_cell.data.Part.cell_x = x;
-        for (uint32 y = 0; y < MAX_NUMBER_OF_CELLS; ++y)
-        {
-            i_cell.data.Part.cell_y = y;
-
-            //Load creatures and game objects
-            TypeContainerVisitor<PersonalPhaseGridLoader, GridTypeMapContainer> visitor(*this);
-            i_grid.VisitGrid(x, y, visitor);
-        }
+        LoadHelper<GameObject>(grid_guids->gameobjects, i_gameObjects, i_map, phaseId, _phaseOwner);
+        LoadHelper<Creature>(grid_guids->creatures, i_creatures, i_map, phaseId, _phaseOwner);
     }
 }
 
@@ -266,6 +171,11 @@ void ObjectGridCleaner::Visit(GridRefManager<T> &m)
         iter->GetSource()->CleanupsBeforeDelete();
     }
 }
+
+template void ObjectGridLoaderBase::AddToMap(GameObject*, Map*, uint32&);
+template void ObjectGridLoaderBase::AddToMap(Creature*, Map*, uint32&);
+template void ObjectGridLoaderBase::AddToMap(AreaTrigger*, Map*, uint32&);
+template void ObjectGridLoaderBase::AddToMap(Corpse*, Map*, uint32&);
 
 template void ObjectGridUnloader::Visit(CreatureMapType &);
 template void ObjectGridUnloader::Visit(GameObjectMapType &);

--- a/src/server/game/Grids/ObjectGridLoader.h
+++ b/src/server/game/Grids/ObjectGridLoader.h
@@ -18,31 +18,29 @@
 #ifndef TRINITY_OBJECT_GRID_LOADER_H
 #define TRINITY_OBJECT_GRID_LOADER_H
 
-#include "Cell.h"
 #include "Define.h"
 #include "GridDefines.h"
 #include "ObjectGuid.h"
 
-class MapObject;
+class Map;
 class ObjectGuid;
-class ObjectWorldLoader;
 
 class TC_GAME_API ObjectGridLoaderBase
 {
     public:
-        ObjectGridLoaderBase(NGridType& grid, Map* map, Cell const& cell)
-            : i_cell(cell), i_grid(grid), i_map(map), i_gameObjects(0), i_creatures(0), i_corpses(0), i_areaTriggers(0)
+        ObjectGridLoaderBase(NGridType& grid, Map* map)
+            : i_grid(grid), i_map(map), i_gameObjects(0), i_creatures(0), i_corpses(0), i_areaTriggers(0)
             { }
-
-        static void SetObjectCell(MapObject* obj, CellCoord const& cellCoord);
 
         uint32 GetLoadedCreatures() const { return i_creatures; }
         uint32 GetLoadedGameObjects() const { return i_gameObjects; }
         uint32 GetLoadedCorpses() const { return i_corpses; }
         uint32 GetLoadedAreaTriggers() const { return i_areaTriggers; }
 
+        template <typename T>
+        static void AddToMap(T* obj, Map* map, uint32& objectCount);
+
     protected:
-        Cell i_cell;
         NGridType &i_grid;
         Map* i_map;
         uint32 i_gameObjects;
@@ -53,20 +51,10 @@ class TC_GAME_API ObjectGridLoaderBase
 
 class TC_GAME_API ObjectGridLoader : public ObjectGridLoaderBase
 {
-    friend class ObjectWorldLoader;
-
     public:
-        ObjectGridLoader(NGridType& grid, Map* map, Cell const& cell)
-            : ObjectGridLoaderBase(grid, map, cell)
+        ObjectGridLoader(NGridType& grid, Map* map)
+            : ObjectGridLoaderBase(grid, map)
             { }
-
-        void Visit(GameObjectMapType &m);
-        void Visit(CreatureMapType &m);
-        void Visit(AreaTriggerMapType &m);
-        void Visit(CorpseMapType &) const { }
-        void Visit(DynamicObjectMapType&) const { }
-        void Visit(SceneObjectMapType&) const { }
-        void Visit(ConversationMapType&) const { }
 
         void LoadN();
 };
@@ -74,22 +62,13 @@ class TC_GAME_API ObjectGridLoader : public ObjectGridLoaderBase
 class TC_GAME_API PersonalPhaseGridLoader : public ObjectGridLoaderBase
 {
     public:
-        PersonalPhaseGridLoader(NGridType& grid, Map* map, Cell const& cell, ObjectGuid const& phaseOwner)
-            : ObjectGridLoaderBase(grid, map, cell), _phaseId(0), _phaseOwner(phaseOwner)
+        PersonalPhaseGridLoader(NGridType& grid, Map* map, ObjectGuid const& phaseOwner)
+            : ObjectGridLoaderBase(grid, map), _phaseOwner(phaseOwner)
             { }
-
-        void Visit(GameObjectMapType &m);
-        void Visit(CreatureMapType &m);
-        void Visit(AreaTriggerMapType&) const { }
-        void Visit(CorpseMapType&) const { }
-        void Visit(DynamicObjectMapType&) const { }
-        void Visit(SceneObjectMapType&) const { }
-        void Visit(ConversationMapType&) const { }
 
         void Load(uint32 phaseId);
 
     private:
-        uint32 _phaseId;
         ObjectGuid _phaseOwner;
 };
 

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -377,6 +377,18 @@ void Map::LoadGridForActiveObject(float x, float y, WorldObject const* object)
     EnsureGridLoadedForActiveObject(Trinity::ComputeGridCoord(x, y), object);
 }
 
+void Map::LoadGridsInRange(float x, float y, float radius)
+{
+    CellArea area = Cell::CalculateCellArea(x, y, std::min(radius, SIZE_OF_GRIDS));
+
+    GridCoord gridAreaLow = Cell(area.low_bound).GetGridCoord();
+    GridCoord gridAreaHigh = Cell(area.high_bound).GetGridCoord();
+
+    for (uint32 gx = gridAreaLow.x_coord; gx <= gridAreaHigh.x_coord; ++gx)
+        for (uint32 gy = gridAreaLow.y_coord; gy <= gridAreaHigh.y_coord; ++gy)
+            EnsureGridLoaded(GridCoord(gx, gy));
+}
+
 bool Map::AddPlayerToMap(Player* player, bool initPlayer /*= true*/)
 {
     CellCoord cellCoord = Trinity::ComputeCellCoord(player->GetPositionX(), player->GetPositionY());
@@ -627,7 +639,6 @@ void Map::VisitNearbyCellsOf(WorldObject* obj, TypeContainerVisitor<Trinity::Obj
             markCell(cell_id);
             CellCoord pair(x, y);
             Cell cell(pair);
-            cell.SetNoCreate();
             Visit(cell, gridVisitor);
             Visit(cell, worldVisitor);
         }
@@ -862,7 +873,6 @@ void Map::ProcessRelocationNotifies(const uint32 diff)
 
                 CellCoord pair(x, y);
                 Cell cell(pair);
-                cell.SetNoCreate();
 
                 Trinity::DelayedUnitRelocation cell_relocation(cell, pair, *this, MAX_VISIBILITY_DISTANCE);
                 TypeContainerVisitor<Trinity::DelayedUnitRelocation, GridTypeMapContainer  > grid_object_relocation(cell_relocation);
@@ -903,7 +913,6 @@ void Map::ProcessRelocationNotifies(const uint32 diff)
 
                 CellCoord pair(x, y);
                 Cell cell(pair);
-                cell.SetNoCreate();
                 Visit(cell, grid_notifier);
                 Visit(cell, world_notifier);
             }

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -112,11 +112,11 @@ Map::~Map()
     m_terrain->UnloadMMapInstance(GetId(), GetInstanceId());
 }
 
-void Map::LoadAllCells()
+void Map::LoadAllGrids()
 {
-    for (uint32 cellX = 0; cellX < TOTAL_NUMBER_OF_CELLS_PER_MAP; cellX++)
-        for (uint32 cellY = 0; cellY < TOTAL_NUMBER_OF_CELLS_PER_MAP; cellY++)
-            LoadGrid((cellX + 0.5f - CENTER_GRID_CELL_ID) * SIZE_OF_GRID_CELL, (cellY + 0.5f - CENTER_GRID_CELL_ID) * SIZE_OF_GRID_CELL);
+    for (uint32 gridX = 0; gridX < MAX_NUMBER_OF_GRIDS; ++gridX)
+        for (uint32 gridY = 0; gridY < MAX_NUMBER_OF_GRIDS; ++gridY)
+            EnsureGridLoaded(GridCoord(gridX, gridY));
 }
 
 void Map::InitStateMachine()
@@ -283,7 +283,7 @@ void Map::EnsureGridCreated(GridCoord const& p)
     {
         TC_LOG_DEBUG("maps", "Creating grid[{}, {}] for map {} instance {}", p.x_coord, p.y_coord, GetId(), i_InstanceId);
 
-        NGridType* ngrid = new NGridType(p.x_coord * MAX_NUMBER_OF_GRIDS + p.y_coord, p.x_coord, p.y_coord, i_gridExpiry, sWorld->getBoolConfig(CONFIG_GRID_UNLOAD));
+        NGridType* ngrid = new NGridType(p.GetId(), p.x_coord, p.y_coord, i_gridExpiry, sWorld->getBoolConfig(CONFIG_GRID_UNLOAD));
         setNGrid(ngrid, p.x_coord, p.y_coord);
 
         // build a linkage between this map and NGridType
@@ -301,38 +301,38 @@ void Map::EnsureGridCreated(GridCoord const& p)
 }
 
 //Load NGrid and make it active
-void Map::EnsureGridLoadedForActiveObject(Cell const& cell, WorldObject const* object)
+void Map::EnsureGridLoadedForActiveObject(GridCoord const& p, WorldObject const* object)
 {
-    EnsureGridLoaded(cell);
-    NGridType *grid = getNGrid(cell.GridX(), cell.GridY());
+    EnsureGridLoaded(p);
+    NGridType *grid = getNGrid(p.x_coord, p.y_coord);
     ASSERT(grid != nullptr);
 
     if (object->IsPlayer())
-        GetMultiPersonalPhaseTracker().LoadGrid(object->GetPhaseShift(), *grid, this, cell);
+        GetMultiPersonalPhaseTracker().LoadGrid(object->GetPhaseShift(), *grid, this);
 
     // refresh grid state & timer
     if (grid->GetGridState() != GRID_STATE_ACTIVE)
     {
-        TC_LOG_DEBUG("maps", "Active object {} triggers loading of grid [{}, {}] on map {}", object->GetGUID().ToString(), cell.GridX(), cell.GridY(), GetId());
+        TC_LOG_DEBUG("maps", "Active object {} triggers loading of grid [{}, {}] on map {}", object->GetGUID().ToString(), p.x_coord, p.y_coord, GetId());
         ResetGridExpiry(*grid, 0.1f);
         grid->SetGridState(GRID_STATE_ACTIVE);
     }
 }
 
 //Create NGrid and load the object data in it
-bool Map::EnsureGridLoaded(Cell const& cell)
+bool Map::EnsureGridLoaded(GridCoord const& p)
 {
-    EnsureGridCreated(GridCoord(cell.GridX(), cell.GridY()));
-    NGridType *grid = getNGrid(cell.GridX(), cell.GridY());
+    EnsureGridCreated(p);
+    NGridType *grid = getNGrid(p.x_coord, p.y_coord);
 
     ASSERT(grid != nullptr);
     if (!grid->isGridObjectDataLoaded())
     {
-        TC_LOG_DEBUG("maps", "Loading grid[{}, {}] for map {} instance {}", cell.GridX(), cell.GridY(), GetId(), i_InstanceId);
+        TC_LOG_DEBUG("maps", "Loading grid[{}, {}] for map {} instance {}", p.x_coord, p.y_coord, GetId(), i_InstanceId);
 
         grid->setGridObjectDataLoaded(true);
 
-        LoadGridObjects(grid, cell);
+        LoadGridObjects(grid);
 
         Balance();
         return true;
@@ -341,19 +341,16 @@ bool Map::EnsureGridLoaded(Cell const& cell)
     return false;
 }
 
-void Map::LoadGridObjects(NGridType* grid, Cell const& cell)
+void Map::LoadGridObjects(NGridType* grid)
 {
-    ObjectGridLoader loader(*grid, this, cell);
+    ObjectGridLoader loader(*grid, this);
     loader.LoadN();
 }
 
 void Map::GridMarkNoUnload(uint32 x, uint32 y)
 {
     // First make sure this grid is loaded
-    float gX = ((float(x) - 0.5f - CENTER_GRID_ID) * SIZE_OF_GRIDS) + (CENTER_GRID_OFFSET * 2);
-    float gY = ((float(y) - 0.5f - CENTER_GRID_ID) * SIZE_OF_GRIDS) + (CENTER_GRID_OFFSET * 2);
-    Cell cell = Cell(gX, gY);
-    EnsureGridLoaded(cell);
+    EnsureGridLoaded(GridCoord(x, y));
 
     // Mark as don't unload
     NGridType* grid = getNGrid(x, y);
@@ -372,12 +369,12 @@ void Map::GridUnmarkNoUnload(uint32 x, uint32 y)
 
 void Map::LoadGrid(float x, float y)
 {
-    EnsureGridLoaded(Cell(x, y));
+    EnsureGridLoaded(Trinity::ComputeGridCoord(x, y));
 }
 
 void Map::LoadGridForActiveObject(float x, float y, WorldObject const* object)
 {
-    EnsureGridLoadedForActiveObject(Cell(x, y), object);
+    EnsureGridLoadedForActiveObject(Trinity::ComputeGridCoord(x, y), object);
 }
 
 bool Map::AddPlayerToMap(Player* player, bool initPlayer /*= true*/)
@@ -390,7 +387,7 @@ bool Map::AddPlayerToMap(Player* player, bool initPlayer /*= true*/)
     }
 
     Cell cell(cellCoord);
-    EnsureGridLoadedForActiveObject(cell, player);
+    EnsureGridLoadedForActiveObject(GridCoord(cell.GridX(), cell.GridY()), player);
     AddToGrid(player, cell);
 
     // Check if we are adding to correct map
@@ -421,8 +418,8 @@ bool Map::AddPlayerToMap(Player* player, bool initPlayer /*= true*/)
 
 void Map::UpdatePersonalPhasesForPlayer(Player const* player)
 {
-    Cell cell(player->GetPositionX(), player->GetPositionY());
-    GetMultiPersonalPhaseTracker().OnOwnerPhaseChanged(player, getNGrid(cell.GridX(), cell.GridY()), this, cell);
+    GridCoord gridCoord = Trinity::ComputeGridCoord(player->GetPositionX(), player->GetPositionY());
+    GetMultiPersonalPhaseTracker().OnOwnerPhaseChanged(player, getNGrid(gridCoord.x_coord, gridCoord.y_coord), this);
 }
 
 int32 Map::GetWorldStateValue(int32 worldStateId) const
@@ -541,7 +538,7 @@ bool Map::AddToMap(T* obj)
 
     Cell cell(cellCoord);
     if (obj->isActiveObject())
-        EnsureGridLoadedForActiveObject(cell, obj);
+        EnsureGridLoadedForActiveObject(GridCoord(cell.GridX(), cell.GridY()), obj);
     else
         EnsureGridCreated(GridCoord(cell.GridX(), cell.GridY()));
     AddToGrid(obj, cell);
@@ -1040,7 +1037,7 @@ void Map::PlayerRelocation(Player* player, float x, float y, float z, float orie
         player->RemoveFromGrid();
 
         if (old_cell.DiffGrid(new_cell))
-            EnsureGridLoadedForActiveObject(new_cell, player);
+            EnsureGridLoadedForActiveObject(GridCoord(new_cell.GridX(), new_cell.GridY()), player);
 
         AddToGrid(player, new_cell);
     }
@@ -1451,10 +1448,12 @@ bool Map::MapObjectCellRelocation(T* object, Cell new_cell, [[maybe_unused]] cha
         return true;
     }
 
+    GridCoord new_grid(new_cell.GridX(), new_cell.GridY());
+
     // in diff. grids but active creature
     if (object->isActiveObject())
     {
-        EnsureGridLoadedForActiveObject(new_cell, object);
+        EnsureGridLoadedForActiveObject(new_grid, object);
 
 #ifdef TRINITY_DEBUG
         TC_LOG_DEBUG("maps", "Active {} {} moved from grid[{}, {}]cell[{}, {}] to grid[{}, {}]cell[{}, {}].", objType, object->GetGUID().ToString(), old_cell.GridX(), old_cell.GridY(), old_cell.CellX(), old_cell.CellY(), new_cell.GridX(), new_cell.GridY(), new_cell.CellX(), new_cell.CellY());
@@ -1468,17 +1467,17 @@ bool Map::MapObjectCellRelocation(T* object, Cell new_cell, [[maybe_unused]] cha
 
     if (Creature* c = object->ToCreature())
         if (c->GetCharmerOrOwnerGUID().IsPlayer())
-            EnsureGridLoaded(new_cell);
+            EnsureGridLoaded(new_grid);
 
     // in diff. loaded grid normal object
-    if (IsGridLoaded(GridCoord(new_cell.GridX(), new_cell.GridY())))
+    if (IsGridLoaded(new_grid))
     {
 #ifdef TRINITY_DEBUG
         TC_LOG_DEBUG("maps", "{} {} moved from grid[{}, {}]cell[{}, {}] to grid[{}, {}]cell[{}, {}].", objType, object->GetGUID().ToString(), old_cell.GridX(), old_cell.GridY(), old_cell.CellX(), old_cell.CellY(), new_cell.GridX(), new_cell.GridY(), new_cell.CellX(), new_cell.CellY());
 #endif
 
         object->RemoveFromGrid();
-        EnsureGridCreated(GridCoord(new_cell.GridX(), new_cell.GridY()));
+        EnsureGridCreated(new_grid);
         AddToGrid(object, new_cell);
 
         return true;
@@ -1672,9 +1671,9 @@ void Map::UnloadAll()
         RemoveFromMap<Transport>(transport, true);
     }
 
-    for (auto& cellCorpsePair : _corpsesByCell)
+    for (auto& [gridId, corpses] : _corpsesByGrid)
     {
-        for (Corpse* corpse : cellCorpsePair.second)
+        for (Corpse* corpse : corpses)
         {
             corpse->RemoveFromWorld();
             corpse->ResetMap();
@@ -1682,7 +1681,7 @@ void Map::UnloadAll()
         }
     }
 
-    _corpsesByCell.clear();
+    _corpsesByGrid.clear();
     _corpsesByPlayer.clear();
     _corpseBones.clear();
 }
@@ -3841,9 +3840,10 @@ void Map::DeleteCorpseData()
 
 void Map::AddCorpse(Corpse* corpse)
 {
+    GridCoord gridCoord = Trinity::ComputeGridCoord(corpse->GetPositionX(), corpse->GetPositionY());
     corpse->SetMap(this);
 
-    _corpsesByCell[corpse->GetCellCoord().GetId()].insert(corpse);
+    _corpsesByGrid[gridCoord.GetId()].insert(corpse);
     if (corpse->GetType() != CORPSE_BONES)
         _corpsesByPlayer[corpse->GetOwnerGUID()] = corpse;
     else
@@ -3852,6 +3852,7 @@ void Map::AddCorpse(Corpse* corpse)
 
 void Map::RemoveCorpse(Corpse* corpse)
 {
+    GridCoord gridCoord = Trinity::ComputeGridCoord(corpse->GetPositionX(), corpse->GetPositionY());
     ASSERT(corpse);
 
     corpse->UpdateObjectVisibilityOnDestroy();
@@ -3863,7 +3864,7 @@ void Map::RemoveCorpse(Corpse* corpse)
         corpse->ResetMap();
     }
 
-    _corpsesByCell[corpse->GetCellCoord().GetId()].erase(corpse);
+    _corpsesByGrid[gridCoord.GetId()].erase(corpse);
     if (corpse->GetType() != CORPSE_BONES)
         _corpsesByPlayer.erase(corpse->GetOwnerGUID());
     else
@@ -3907,7 +3908,6 @@ Corpse* Map::ConvertCorpseToBones(ObjectGuid const& ownerGuid, bool insignia /*=
         bones->ReplaceAllFlags(corpse->m_corpseData->Flags | CORPSE_FLAG_BONES);
         bones->SetFactionTemplate(corpse->m_corpseData->FactionTemplate);
 
-        bones->SetCellCoord(corpse->GetCellCoord());
         bones->Relocate(corpse->GetPositionX(), corpse->GetPositionY(), corpse->GetPositionZ(), corpse->GetOrientation());
 
         PhasingHandler::InheritPhaseShift(bones, corpse);
@@ -4113,7 +4113,7 @@ std::string Map::GetDebugInfo() const
 {
     std::stringstream sstr;
     sstr << std::boolalpha
-        << "Id: " << GetId() << " InstanceId: " << GetInstanceId() << " Difficulty: " << std::to_string(GetDifficultyID())
+        << "Id: " << GetId() << " InstanceId: " << GetInstanceId() << " Difficulty: " << AsUnderlyingType(GetDifficultyID())
         << " HasPlayers: " << HavePlayers();
     return sstr.str();
 }

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -379,10 +379,10 @@ void Map::LoadGridForActiveObject(float x, float y, WorldObject const* object)
 
 void Map::LoadGridsInRange(float x, float y, float radius)
 {
-    CellArea area = Cell::CalculateCellArea(x, y, std::min(radius, SIZE_OF_GRIDS));
+    radius = std::min(radius, SIZE_OF_GRIDS);
 
-    GridCoord gridAreaLow = Cell(area.low_bound).GetGridCoord();
-    GridCoord gridAreaHigh = Cell(area.high_bound).GetGridCoord();
+    GridCoord gridAreaLow = Trinity::ComputeGridCoord(x - radius, y - radius);
+    GridCoord gridAreaHigh = Trinity::ComputeGridCoord(x + radius, y + radius);
 
     for (uint32 gx = gridAreaLow.x_coord; gx <= gridAreaHigh.x_coord; ++gx)
         for (uint32 gy = gridAreaLow.y_coord; gy <= gridAreaHigh.y_coord; ++gy)

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -282,6 +282,7 @@ class TC_GAME_API Map : public GridRefManager<NGridType>
         void SetUnloadLock(GridCoord const& p, bool on) { getNGrid(p.x_coord, p.y_coord)->setUnloadExplicitLock(on); }
         void LoadGrid(float x, float y);
         void LoadGridForActiveObject(float x, float y, WorldObject const* object);
+        void LoadGridsInRange(float x, float y, float radius);
         void LoadAllGrids();
         bool UnloadGrid(NGridType& ngrid, bool pForce);
         void GridMarkNoUnload(uint32 x, uint32 y);
@@ -960,9 +961,6 @@ inline void Map::Visit(Cell const& cell, TypeContainerVisitor<T, CONTAINER>& vis
     const uint32 y = cell.GridY();
     const uint32 cell_x = cell.CellX();
     const uint32 cell_y = cell.CellY();
-
-    if (!cell.NoCreate())
-        EnsureGridLoaded(GridCoord(x, y));
 
     NGridType* grid = getNGrid(x, y);
     if (grid && grid->isGridObjectDataLoaded())

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -282,7 +282,7 @@ class TC_GAME_API Map : public GridRefManager<NGridType>
         void SetUnloadLock(GridCoord const& p, bool on) { getNGrid(p.x_coord, p.y_coord)->setUnloadExplicitLock(on); }
         void LoadGrid(float x, float y);
         void LoadGridForActiveObject(float x, float y, WorldObject const* object);
-        void LoadAllCells();
+        void LoadAllGrids();
         bool UnloadGrid(NGridType& ngrid, bool pForce);
         void GridMarkNoUnload(uint32 x, uint32 y);
         void GridUnmarkNoUnload(uint32 x, uint32 y);
@@ -473,10 +473,10 @@ class TC_GAME_API Map : public GridRefManager<NGridType>
         AreaTriggerBySpawnIdContainer& GetAreaTriggerBySpawnIdStore() { return _areaTriggerBySpawnIdStore; }
         AreaTriggerBySpawnIdContainer const& GetAreaTriggerBySpawnIdStore() const { return _areaTriggerBySpawnIdStore; }
 
-        std::unordered_set<Corpse*> const* GetCorpsesInCell(uint32 cellId) const
+        std::unordered_set<Corpse*> const* GetCorpsesInGrid(uint32 cellId) const
         {
-            auto itr = _corpsesByCell.find(cellId);
-            if (itr != _corpsesByCell.end())
+            auto itr = _corpsesByGrid.find(cellId);
+            if (itr != _corpsesByGrid.end())
                 return &itr->second;
 
             return nullptr;
@@ -626,10 +626,10 @@ class TC_GAME_API Map : public GridRefManager<NGridType>
         bool _areaTriggersToMoveLock;
         std::vector<AreaTrigger*> _areaTriggersToMove;
 
-        bool IsGridLoaded(GridCoord const&) const;
-        void EnsureGridCreated(GridCoord const&);
-        bool EnsureGridLoaded(Cell const&);
-        void EnsureGridLoadedForActiveObject(Cell const&, WorldObject const* object);
+        bool IsGridLoaded(GridCoord const& p) const;
+        void EnsureGridCreated(GridCoord const& p);
+        bool EnsureGridLoaded(GridCoord const& p);
+        void EnsureGridLoadedForActiveObject(GridCoord const& p, WorldObject const* object);
 
         void buildNGridLinkage(NGridType* pNGridType) { pNGridType->link(this); }
 
@@ -645,7 +645,7 @@ class TC_GAME_API Map : public GridRefManager<NGridType>
         void SendObjectUpdates();
 
     protected:
-        virtual void LoadGridObjects(NGridType* grid, Cell const& cell);
+        virtual void LoadGridObjects(NGridType* grid);
 
         MapEntry const* i_mapEntry;
         Difficulty i_spawnMode;
@@ -765,6 +765,8 @@ class TC_GAME_API Map : public GridRefManager<NGridType>
 
     private:
         // Type specific code for add/remove to/from grid
+        friend class ObjectGridLoaderBase;
+
         template<class T>
         void AddToGrid(T* object, Cell const& cell);
 
@@ -820,7 +822,7 @@ class TC_GAME_API Map : public GridRefManager<NGridType>
         CreatureBySpawnIdContainer _creatureBySpawnIdStore;
         GameObjectBySpawnIdContainer _gameobjectBySpawnIdStore;
         AreaTriggerBySpawnIdContainer _areaTriggerBySpawnIdStore;
-        std::unordered_map<uint32/*cellId*/, std::unordered_set<Corpse*>> _corpsesByCell;
+        std::unordered_map<uint32/*cellId*/, std::unordered_set<Corpse*>> _corpsesByGrid;
         std::unordered_map<ObjectGuid, Corpse*> _corpsesByPlayer;
         std::unordered_set<Corpse*> _corpseBones;
 
@@ -960,7 +962,7 @@ inline void Map::Visit(Cell const& cell, TypeContainerVisitor<T, CONTAINER>& vis
     const uint32 cell_y = cell.CellY();
 
     if (!cell.NoCreate())
-        EnsureGridLoaded(cell);
+        EnsureGridLoaded(GridCoord(x, y));
 
     NGridType* grid = getNGrid(x, y);
     if (grid && grid->isGridObjectDataLoaded())

--- a/src/server/game/Maps/MapManager.cpp
+++ b/src/server/game/Maps/MapManager.cpp
@@ -83,7 +83,7 @@ Map* MapManager::CreateWorldMap(uint32 mapId, uint32 instanceId)
     map->InitSpawnGroupState();
 
     if (sWorld->getBoolConfig(CONFIG_BASEMAP_LOAD_GRIDS))
-        map->LoadAllCells();
+        map->LoadAllGrids();
 
     return map;
 }
@@ -118,7 +118,7 @@ InstanceMap* MapManager::CreateInstance(uint32 mapId, uint32 instanceId, Instanc
     map->InitSpawnGroupState();
 
     if (sWorld->getBoolConfig(CONFIG_INSTANCEMAP_LOAD_GRIDS))
-        map->LoadAllCells();
+        map->LoadAllGrids();
 
     return map;
 }
@@ -136,7 +136,7 @@ BattlegroundMap* MapManager::CreateBattleground(uint32 mapId, uint32 instanceId,
     map->GetBattlegroundScript()->OnInit();
 
     if (sWorld->getBoolConfig(CONFIG_BATTLEGROUNDMAP_LOAD_GRIDS))
-        map->LoadAllCells();
+        map->LoadAllGrids();
 
     return map;
 }

--- a/src/server/game/Phasing/PersonalPhaseTracker.cpp
+++ b/src/server/game/Phasing/PersonalPhaseTracker.cpp
@@ -116,12 +116,12 @@ void PlayerPersonalPhasesTracker::DespawnPhase(Map* map, PersonalPhaseSpawns& sp
 /***             MultiPersonalPhaseTracker             ***/
 /*********************************************************/
 
-void MultiPersonalPhaseTracker::LoadGrid(PhaseShift const& phaseShift, NGridType& grid, Map* map, Cell const& cell)
+void MultiPersonalPhaseTracker::LoadGrid(PhaseShift const& phaseShift, NGridType& grid, Map* map)
 {
     if (!phaseShift.HasPersonalPhase())
         return;
 
-    PersonalPhaseGridLoader loader(grid, map, cell, phaseShift.GetPersonalGuid());
+    PersonalPhaseGridLoader loader(grid, map, phaseShift.GetPersonalGuid());
     PlayerPersonalPhasesTracker& playerTracker = _playerData[phaseShift.GetPersonalGuid()];
 
     for (PhaseShift::PhaseRef const& phaseRef : phaseShift.GetPhases())
@@ -136,7 +136,7 @@ void MultiPersonalPhaseTracker::LoadGrid(PhaseShift const& phaseShift, NGridType
             continue;
 
         TC_LOG_DEBUG("maps", "Loading personal phase objects (phase {}) in grid[{}, {}] for map {} instance {}",
-            phaseRef.Id, cell.GridX(), cell.GridY(), map->GetId(), map->GetInstanceId());
+            phaseRef.Id, grid.getX(), grid.getY(), map->GetId(), map->GetInstanceId());
 
         loader.Load(phaseRef.Id);
 
@@ -174,13 +174,13 @@ void MultiPersonalPhaseTracker::UnregisterTrackedObject(WorldObject* object)
         playerTracker->UnregisterTrackedObject(object);
 }
 
-void MultiPersonalPhaseTracker::OnOwnerPhaseChanged(WorldObject const* phaseOwner, NGridType* grid, Map* map, Cell const& cell)
+void MultiPersonalPhaseTracker::OnOwnerPhaseChanged(WorldObject const* phaseOwner, NGridType* grid, Map* map)
 {
     if (PlayerPersonalPhasesTracker* playerTracker = Trinity::Containers::MapGetValuePtr(_playerData, phaseOwner->GetGUID()))
         playerTracker->OnOwnerPhasesChanged(phaseOwner);
 
     if (grid)
-        LoadGrid(phaseOwner->GetPhaseShift(), *grid, map, cell);
+        LoadGrid(phaseOwner->GetPhaseShift(), *grid, map);
 }
 
 void MultiPersonalPhaseTracker::MarkAllPhasesForDeletion(ObjectGuid const& phaseOwner)

--- a/src/server/game/Phasing/PersonalPhaseTracker.h
+++ b/src/server/game/Phasing/PersonalPhaseTracker.h
@@ -27,7 +27,6 @@
 class Map;
 class PhaseShift;
 class WorldObject;
-struct Cell;
 
 struct PersonalPhaseSpawns
 {
@@ -67,13 +66,13 @@ private:
 /* Handles personal phase trackers for all owners */
 struct MultiPersonalPhaseTracker
 {
-    void LoadGrid(PhaseShift const& phaseShift, NGridType& grid, Map* map, Cell const& cell);
+    void LoadGrid(PhaseShift const& phaseShift, NGridType& grid, Map* map);
     void UnloadGrid(NGridType& grid);
 
     void RegisterTrackedObject(uint32 phaseId, ObjectGuid const& phaseOwner, WorldObject* object);
     void UnregisterTrackedObject(WorldObject* object);
 
-    void OnOwnerPhaseChanged(WorldObject const* phaseOwner, NGridType* grid, Map* map, Cell const& cell);
+    void OnOwnerPhaseChanged(WorldObject const* phaseOwner, NGridType* grid, Map* map);
     void MarkAllPhasesForDeletion(ObjectGuid const& phaseOwner);
 
     void Update(Map* map, uint32 diff);

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2170,13 +2170,8 @@ void Spell::SearchTargets(SEARCHER& searcher, uint32 containerMask, WorldObject*
     bool searchInWorld = (containerMask & (GRID_MAP_TYPE_MASK_CREATURE | GRID_MAP_TYPE_MASK_PLAYER | GRID_MAP_TYPE_MASK_CORPSE)) != 0;
     if (searchInGrid || searchInWorld)
     {
-        float x, y;
-        x = pos->GetPositionX();
-        y = pos->GetPositionY();
-
-        CellCoord p(Trinity::ComputeCellCoord(x, y));
-        Cell cell(p);
-        cell.SetNoCreate();
+        float x = pos->GetPositionX();
+        float y = pos->GetPositionY();
 
         Map* map = referer->GetMap();
 

--- a/src/server/scripts/Commands/cs_debug.cpp
+++ b/src/server/scripts/Commands/cs_debug.cpp
@@ -1312,7 +1312,7 @@ public:
         {
             handler->PSendSysMessage("Loading all cells (mapId: %u). Current GameObjects " SZFMTD ", Creatures " SZFMTD, map->GetId(), map->GetObjectsStore().Size<GameObject>(), map->GetObjectsStore().Size<Creature>());
 
-            map->LoadAllCells();
+            map->LoadAllGrids();
 
             handler->PSendSysMessage("Cells loaded (mapId: %u) After load - GameObject " SZFMTD ", Creatures " SZFMTD, map->GetId(), map->GetObjectsStore().Size<GameObject>(), map->GetObjectsStore().Size<Creature>());
         }


### PR DESCRIPTION
## Summary

The scheduled `merge` workflow merges `TrinityCore/TrinityCore` `master` into `gomove_master` and builds with `-DWITH_WARNINGS_AS_ERRORS=1`. Job [`_master (gomove_master, ON)`](https://github.com/Rochet2/TrinityCore/actions/runs/30415818285/job/90461987504) failed after a clean upstream merge.

This PR merges the latest upstream `master` into `gomove_master` and adapts GOMove to the new grid visitor API.

## What was wrong

### Post-merge compile error

1. **`GOMove.cpp`** — `Cell::VisitGridObjects(player, searcher, SIZE_OF_GRIDS, false)` still passed the removed `dont_load` argument. Upstream now only accepts the 3-arg form `(WorldObject const*, T& visitor, float radius)` (see Core/Grids: Decouple grid loading from searchers).

## What was fixed

| Area | Result |
|------|--------|
| Merge topology | Proper 2-parent merge of current `master` |
| `GOMove.cpp` | Dropped the 4th `false` argument |

## Verification

- Confirmed against failing CI log: only this call site failed.
- Grep: no remaining `VisitGridObjects(..., true/false)` in `src/`.
- Local Windows MSBuild of master was not run (workspace `BUILD/` is configured for 3.3.5).

## Test plan

- [ ] Merge this PR into `gomove_master`.
- [ ] Confirm the `merge` workflow `_master (gomove_master, …)` jobs pass.
- [ ] In-game: load the GOMove addon and verify nearby GO listing still works.
